### PR TITLE
Add json tags to Connector and Secrets

### DIFF
--- a/iscsi/iscsiadm.go
+++ b/iscsi/iscsiadm.go
@@ -11,15 +11,15 @@ import (
 // Secrets provides optional iscsi security credentials (CHAP settings)
 type Secrets struct {
 	// SecretsType is the type of Secrets being utilized (currently we only impleemnent "chap"
-	SecretsType string
+	SecretsType string `json:"secretsType,omitempty"`
 	// UserName is the configured iscsi user login
-	UserName string
+	UserName string `json:"userName"`
 	// Password is the configured iscsi password
-	Password string
+	Password string `json:"password"`
 	// UserNameIn provides a specific input login for directional CHAP configurations
-	UserNameIn string
+	UserNameIn string `json:"userNameIn,omitempty"`
 	// PasswordIn provides a specific input password for directional CHAP configurations
-	PasswordIn string
+	PasswordIn string `json:"passwordIn,omitempty"`
 }
 
 // CmdError is a custom error to provide details including the command, stderr output and exit code.


### PR DESCRIPTION
This change adds json tags to the Connector struct and the Secret struct
in the iscsi lib.  This enables us to add the ability to persist a
Connection into a json file, which can then be used to easily rebuild a
Connector for Disconnect, or other DR purposes.