### PR TITLE
Remove logging of args for failed iscsi cmds

### DIFF
--- a/iscsi/iscsi.go
+++ b/iscsi/iscsi.go
@@ -273,6 +273,7 @@ func Connect(c Connector) (string, error) {
 		// create db entry
 		args := append(baseArgs, []string{"-I", iFace, "-o", "new"}...)
 		debug.Printf("create the new record: %s\n", args)
+		// Make sure we don't log the secrets
 		err := CreateDBEntry(c.TargetIqn, p, iFace, c.DiscoverySecrets, c.SessionSecrets)
 		if err != nil {
 			debug.Printf("Error creating db entry: %s\n", err.Error())


### PR DESCRIPTION
The iscsiadm functions provide a debug mode that currently logs the
iscsiadm command that was issued and the response.  This is handy for
the lib as it's in beta and we want to make it easy for users to pick up
and start using, BUT it also has a major problem in that it will also
log the arguments passed in for things like CHAP secrets.

This change just removes the debug logging of the iscsiadm cmd args, in
the future if we need/want some debug tools we can implement a more
robust and secure method that's safe and doesn't leak secrets to log
files.

closes #8