### PR TITLE
use os.IsNotExist and other small fixes

### DIFF
--- a/iscsi/iscsi.go
+++ b/iscsi/iscsi.go
@@ -96,7 +96,6 @@ func sessionExists(tgtPortal, tgtIQN string) (bool, error) {
 	if err != nil {
 		return false, err
 	}
-	var existingSessions []iscsiSession
 	for _, s := range sessions {
 		if tgtIQN == s.IQN && tgtPortal == s.Portal {
 			return true, nil

--- a/iscsi/iscsi.go
+++ b/iscsi/iscsi.go
@@ -99,14 +99,10 @@ func sessionExists(tgtPortal, tgtIQN string) (bool, error) {
 	var existingSessions []iscsiSession
 	for _, s := range sessions {
 		if tgtIQN == s.IQN && tgtPortal == s.Portal {
-			existingSessions = append(existingSessions, s)
+			return true, nil
 		}
 	}
-	exists := false
-	if len(existingSessions) > 0 {
-		exists = true
-	}
-	return exists, nil
+	return false, nil
 }
 
 func extractTransportName(output string) string {
@@ -130,8 +126,8 @@ func getCurrentSessions() ([]iscsiSession, error) {
 		}
 		return nil, err
 	}
-	session := parseSessions(out)
-	return session, err
+	sessions := parseSessions(out)
+	return sessions, err
 }
 
 func waitForPathToExist(devicePath *string, maxRetries, intervalSeconds int, deviceTransport string) (bool, error) {
@@ -148,7 +144,7 @@ func waitForPathToExistImpl(devicePath *string, maxRetries, intervalSeconds int,
 		err = nil
 		if deviceTransport == "tcp" {
 			_, err = osStat(*devicePath)
-			if err != nil && !strings.Contains(err.Error(), "no such file or directory") {
+			if err != nil && !os.IsNotExist(err) {
 				debug.Printf("Error attempting to stat device: %s", err.Error())
 				return false, err
 			} else if err != nil {


### PR DESCRIPTION
**What type of PR is this?**
 /kind flake

**What this PR does / why we need it**:
This PR uses os.IsNotExist to verify if the file is not exist instead of checking the key words in the error message, because the words might be different in different OS and may be changed over time.
This PR also adds two small fixes.

**Which issue(s) this PR fixes**:
Fixes #

**Special notes for your reviewer**:

**Does this PR introduce a user-facing change?**:
```release-note
NONE
```
