### PR TITLE
improve discoverydb method

### DIFF
--- a/iscsi/iscsi.go
+++ b/iscsi/iscsi.go
@@ -52,7 +52,7 @@ type Connector struct {
 	Multipath        bool         `json:"multipath"`
 	RetryCount       int32        `json:"retry_count"`
 	CheckInterval    int32        `json:"check_interval"`
-	DoDiscoverydb    bool         `json:"do_discovery"`
+	DoDiscovery      bool         `json:"do_discovery"`
 	DoCHAPDiscovery  bool         `json:"do_chap_discovery"`
 }
 
@@ -281,7 +281,7 @@ func Connect(c Connector) (string, error) {
 			}
 		}
 
-		if c.DoDiscoverydb {
+		if c.DoDiscovery {
 			// build discoverydb and discover iscsi target
 			if err := Discoverydb(p, iFace, c.DiscoverySecrets, c.DoCHAPDiscovery); err != nil {
 				debug.Printf("Error in discovery of the target: %s\n", err.Error())

--- a/iscsi/iscsi.go
+++ b/iscsi/iscsi.go
@@ -52,7 +52,7 @@ type Connector struct {
 	Multipath        bool         `json:"multipath"`
 	RetryCount       int32        `json:"retry_count"`
 	CheckInterval    int32        `json:"check_interval"`
-	DoDiscovery      bool         `json:"do_discovery"`
+	DoDiscoverydb    bool         `json:"do_discovery"`
 	DoCHAPDiscovery  bool         `json:"do_chap_discovery"`
 }
 
@@ -281,20 +281,22 @@ func Connect(c Connector) (string, error) {
 			}
 		}
 
-		if c.DoDiscovery {
+		if c.DoDiscoverydb {
 			// build discoverydb and discover iscsi target
-			if err := Discovery(p, iFace, c.DiscoverySecrets, c.DoCHAPDiscovery); err != nil {
+			if err := Discoverydb(p, iFace, c.DiscoverySecrets, c.DoCHAPDiscovery); err != nil {
 				debug.Printf("Error in discovery of the target: %s\n", err.Error())
 				lastErr = err
 				continue
 			}
 		}
 
-		// Make sure we don't log the secrets
-		err := CreateDBEntry(target.Iqn, p, iFace, c.DiscoverySecrets, c.SessionSecrets, c.DoCHAPDiscovery)
-		if err != nil {
-			debug.Printf("Error creating db entry: %s\n", err.Error())
-			continue
+		if c.DoCHAPDiscovery {
+			// Make sure we don't log the secrets
+			err := CreateDBEntry(target.Iqn, p, iFace, c.DiscoverySecrets, c.SessionSecrets)
+			if err != nil {
+				debug.Printf("Error creating db entry: %s\n", err.Error())
+				continue
+			}
 		}
 
 		// perform the login

--- a/iscsi/iscsiadm_test.go
+++ b/iscsi/iscsiadm_test.go
@@ -65,9 +65,9 @@ iscsiadm: Could not perform SendTargets discovery.\n`,
 		t.Run(name, func(t *testing.T) {
 			mockedExitStatus = tt.mockedExitStatus
 			mockedStdout = tt.mockedStdout
-			err := Discovery(tt.tgtPortal, tt.iface, tt.discoverySecret, tt.chapDiscovery)
+			err := Discoverydb(tt.tgtPortal, tt.iface, tt.discoverySecret, tt.chapDiscovery)
 			if (err != nil) != tt.wantErr {
-				t.Errorf("Discovery() error = %v, wantErr %v", err, tt.wantErr)
+				t.Errorf("Discoverydb() error = %v, wantErr %v", err, tt.wantErr)
 				return
 			}
 		})
@@ -82,19 +82,10 @@ func TestCreateDBEntry(t *testing.T) {
 		iface            string
 		discoverySecret  Secrets
 		sessionSecret    Secrets
-		chapDiscovery    bool
 		wantErr          bool
 		mockedStdout     string
 		mockedExitStatus int
 	}{
-		"CreateDBEntrySuccess": {
-			tgtPortal:        "192.168.1.107:3260",
-			tgtIQN:           "iqn.2010-10.org.openstack:volume-eb393993-73d0-4e39-9ef4-b5841e244ced",
-			iface:            "default",
-			chapDiscovery:    false,
-			mockedStdout:     nodeDB,
-			mockedExitStatus: 0,
-		},
 		"CreateDBEntryWithChapDiscoverySuccess": {
 			tgtPortal: "192.168.1.107:3260",
 			tgtIQN:    "iqn.2010-10.org.openstack:volume-eb393993-73d0-4e39-9ef4-b5841e244ced",
@@ -109,7 +100,6 @@ func TestCreateDBEntry(t *testing.T) {
 				PasswordIn:  "dummypass",
 				SecretsType: "chap",
 			},
-			chapDiscovery:    true,
 			mockedStdout:     nodeDB,
 			mockedExitStatus: 0,
 		},
@@ -117,7 +107,6 @@ func TestCreateDBEntry(t *testing.T) {
 			tgtPortal:        "172.18.0.2:3260",
 			tgtIQN:           "iqn.2016-09.com.openebs.jiva:store1",
 			iface:            "default",
-			chapDiscovery:    true,
 			mockedStdout:     "iscsiadm: No records found\n",
 			mockedExitStatus: 21,
 			wantErr:          true,
@@ -128,7 +117,7 @@ func TestCreateDBEntry(t *testing.T) {
 		t.Run(name, func(t *testing.T) {
 			mockedExitStatus = tt.mockedExitStatus
 			mockedStdout = tt.mockedStdout
-			err := CreateDBEntry(tt.tgtIQN, tt.tgtPortal, tt.iface, tt.discoverySecret, tt.sessionSecret, tt.chapDiscovery)
+			err := CreateDBEntry(tt.tgtIQN, tt.tgtPortal, tt.iface, tt.discoverySecret, tt.sessionSecret)
 			if (err != nil) != tt.wantErr {
 				t.Errorf("CreateDBEntry() error = %v, wantErr %v", err, tt.wantErr)
 				return


### PR DESCRIPTION
**What type of PR is this?**
/kind flake

**What this PR does / why we need it**:
This PR:
1. Rename Discovery to Discoverydb because it it different in iscsiadm command.
2. Move DoCHAPDiscovery check out of CreateDBEntry method.
3. Remove updateISCSIDiscoverydb because it is duplicate to createCHAPEntries.

**Which issue(s) this PR fixes**:
Fixes #

**Special notes for your reviewer**:

**Does this PR introduce a user-facing change?**:

```release-note
NONE
```