### PR TITLE
enable debug log in unittests

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,3 +1,21 @@
+# Copyright 2020 The Kubernetes Authors.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+
+DEBUG ?= "false"
+TEST ?= "^[\s\S]+$$"
+
 .PHONY: all build clean install
 
 all: clean build install
@@ -14,5 +32,10 @@ install:
 	go install ./iscsi/
 
 test:
-	go test ./iscsi/
+ifeq ($(DEBUG), true)
+	@export DEBUG
+	go test ./iscsi/ -v -run $(TEST)
+else
+	go test ./iscsi
+endif
 

--- a/iscsi/iscsi_test.go
+++ b/iscsi/iscsi_test.go
@@ -83,6 +83,12 @@ var testCmdError error
 var mockedExitStatus = 0
 var mockedStdout string
 
+func init() {
+	if os.Getenv("DEBUG") == "true" {
+		EnableDebugLogging(os.Stderr)
+	}
+}
+
 type testCmdRunner struct{}
 
 func fakeExecCommand(command string, args ...string) *exec.Cmd {


### PR DESCRIPTION
**What type of PR is this?**
/kind flake

**What this PR does / why we need it**:
This pr enable the debug log in unittest, which is helpful when you debug something or wirte new functions/unittests.
How to use it:
1. Use `make test` to run all unittests, without any log, the default way.
2. Use `make test  DEBUG=true` to run all unittests, it will print the logs.
3. Use `make test  DEBUG=true TEST=TestCreateDBEntry` to run all sub-tests under `TestCreateDBEntry`, it will print the logs.
3. Use `make test  DEBUG=true TEST=TestCreateDBEntry/CreateDBEntryWithChapDiscoveryFailure` to run the test `CreateDBEntryWithChapDiscoveryFailure` under `TestCreateDBEntry`, it will print the logs.

**Which issue(s) this PR fixes**:
Fixes #

**Special notes for your reviewer**:

**Does this PR introduce a user-facing change?**:
```release-note
NONE
```
