### PR TITLE
Fix build issues.

### DIFF
--- a/example/main.go
+++ b/example/main.go
@@ -33,6 +33,10 @@ func main() {
 		log.Printf("Failed to parse portals: %s.", err)
 		os.Exit(1)
 	}
+	if len(targets) == 0 {
+		log.Printf("No portals specified.")
+		os.Exit(1)
+	}
 
 	// You can utilize the iscsiadm calls directly if you wish, but by creating a Connector
 	// you can simplify interactions to simple calls like "Connect" and "Disconnect"

--- a/iscsi/iscsi.go
+++ b/iscsi/iscsi.go
@@ -376,7 +376,7 @@ func DisconnectVolume(c Connector) error {
 		if err != nil {
 			return err
 		}
-		err := FlushMultipathDevice(c.DevicePath)
+		err = FlushMultipathDevice(c.DevicePath)
 		if err != nil {
 			return err
 		}


### PR DESCRIPTION
The example does not match the signatures in the library code.
Also fixes build issue (redeclaring `err`) in the library. Probably used to work in older Go verisons.

<!--  Thanks for sending a pull request!  Here are some tips for you:

1. If this is your first time, please read our contributor guidelines: https://git.k8s.io/community/contributors/guide#your-first-contribution and developer guide https://git.k8s.io/community/contributors/devel/development.md#development-guide
2. Follow the instructions for writing a release note: https://git.k8s.io/community/contributors/guide/release-notes.md
3. If the PR is unfinished, see how to mark it: https://git.k8s.io/community/contributors/guide/pull-requests.md#marking-unfinished-pull-requests
-->

**What type of PR is this?**
> Uncomment only one ` /kind <>` line, hit enter to put that in a new line, and remove leading whitespaces from that line:
>
> /kind api-change

/kind bug

> /kind cleanup
> /kind design
> /kind documentation
> /kind failing-test
> /kind feature
> /kind flake

**What this PR does / why we need it**:
Fixes build issues in the example, which no longer matches function signatures in the library code itself.

**Which issue(s) this PR fixes**:
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
_If PR is about `failing-tests or flakes`, please post the related issues/tests in a comment and do not use `Fixes`_*
-->
Fixes #

**Special notes for your reviewer**:

**Does this PR introduce a user-facing change?**:
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".
-->
```release-note
NONE
```
