### PR TITLE
Fix/disconnect volume

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,4 +1,4 @@
-.PHONY: all build clean install
+.PHONY: all build clean install test coverage
 
 all: clean build install
 
@@ -16,3 +16,6 @@ install:
 test:
 	go test ./iscsi/
 
+coverage:
+	go test ./iscsi -coverprofile=coverage.out
+	go tool cover -html=coverage.out

--- a/example/main.go
+++ b/example/main.go
@@ -26,25 +26,14 @@ func main() {
 		iscsi.EnableDebugLogging(os.Stdout)
 	}
 
-	var targets []iscsi.TargetInfo
-
-	for _, tgtp := range tgtps {
-		parts := strings.Split(tgtp, ":")
-		targets = append(targets, iscsi.TargetInfo{
-			// Specify the target iqn we're dealing with
-			Iqn:    *iqn,
-			Portal: parts[0],
-			Port:   parts[1],
-		})
-	}
-
 	// You can utilize the iscsiadm calls directly if you wish, but by creating a Connector
 	// you can simplify interactions to simple calls like "Connect" and "Disconnect"
 	c := &iscsi.Connector{
 		// Our example uses chap
 		AuthType: "chap",
 		// List of targets must be >= 1 (>1 signals multipath/mpio)
-		Targets: targets,
+		TargetIqn:     *iqn,
+		TargetPortals: tgtps,
 		// CHAP can be setup up for discovery as well as sessions, our example
 		// device only uses CHAP security for sessions, for those that use Discovery
 		// as well, we'd add a DiscoverySecrets entry the same way

--- a/example/main.go
+++ b/example/main.go
@@ -13,7 +13,6 @@ import (
 var (
 	portals   = flag.String("portals", "192.168.1.112:3260", "Comma delimited.  Eg: 1.1.1.1,2.2.2.2")
 	iqn       = flag.String("iqn", "iqn.2010-10.org.openstack:volume-95739000-1557-44f8-9f40-e9d29fe6ec47", "")
-	multipath = flag.Bool("multipath", false, "")
 	username  = flag.String("username", "3aX7EEf3CEgvESQG75qh", "")
 	password  = flag.String("password", "eJBDC7Bt7WE3XFDq", "")
 	lun       = flag.Int("lun", 1, "")
@@ -41,7 +40,7 @@ func main() {
 
 	// You can utilize the iscsiadm calls directly if you wish, but by creating a Connector
 	// you can simplify interactions to simple calls like "Connect" and "Disconnect"
-	c := iscsi.Connector{
+	c := &iscsi.Connector{
 		// Our example uses chap
 		AuthType: "chap",
 		// List of targets must be >= 1 (>1 signals multipath/mpio)
@@ -55,8 +54,6 @@ func main() {
 			SecretsType: "chap"},
 		// Lun is the lun number the devices uses for exports
 		Lun: int32(*lun),
-		// Multipath indicates that we want to configure this connection as a multipath device
-		Multipath: *multipath,
 		// Number of times we check for device path, waiting for CheckInterval seconds inbetween each check (defaults to 10 if omitted)
 		RetryCount: 11,
 		// CheckInterval is the time in seconds to wait inbetween device path checks when logging in to a target
@@ -68,11 +65,6 @@ func main() {
 	path, err := iscsi.Connect(c)
 	if err != nil {
 		log.Printf("Error returned from iscsi.Connect: %s", err.Error())
-		os.Exit(1)
-	}
-
-	if path == "" {
-		log.Printf("Failed to connect, didn't receive a path, but also no error!")
 		os.Exit(1)
 	}
 

--- a/go.mod
+++ b/go.mod
@@ -2,4 +2,7 @@ module github.com/kubernetes-csi/csi-lib-iscsi
 
 go 1.15
 
-require github.com/prashantv/gostub v1.0.0
+require (
+	github.com/prashantv/gostub v1.0.0
+	github.com/stretchr/testify v1.7.0
+)

--- a/go.mod
+++ b/go.mod
@@ -1,3 +1,5 @@
 module github.com/kubernetes-csi/csi-lib-iscsi
 
 go 1.15
+
+require github.com/prashantv/gostub v1.0.0

--- a/go.mod
+++ b/go.mod
@@ -1,0 +1,3 @@
+module github.com/kubernetes-csi/csi-lib-iscsi
+
+go 1.15

--- a/go.sum
+++ b/go.sum
@@ -1,0 +1,2 @@
+github.com/prashantv/gostub v1.0.0 h1:wTzvgO04xSS3gHuz6Vhuo0/kvWelyJxwNS0IRBPAwGY=
+github.com/prashantv/gostub v1.0.0/go.mod h1:dP1v6T1QzyGJJKFocwAU0lSZKpfjstjH8TlhkEU0on0=

--- a/go.sum
+++ b/go.sum
@@ -7,6 +7,7 @@ github.com/prashantv/gostub v1.0.0/go.mod h1:dP1v6T1QzyGJJKFocwAU0lSZKpfjstjH8Tl
 github.com/stretchr/objx v0.1.0/go.mod h1:HFkY916IF+rwdDfMAkV7OtwuqBVzrE8GR6GFx+wExME=
 github.com/stretchr/testify v1.7.0 h1:nwc3DEeHmmLAfoZucVR881uASk0Mfjw8xYJ99tb5CcY=
 github.com/stretchr/testify v1.7.0/go.mod h1:6Fq8oRcR53rry900zMqJjRRixrwX3KX962/h/Wwjteg=
+gopkg.in/check.v1 v0.0.0-20161208181325-20d25e280405 h1:yhCVgyC4o1eVCa2tZl7eS0r+SDo693bJlVdllGtEeKM=
 gopkg.in/check.v1 v0.0.0-20161208181325-20d25e280405/go.mod h1:Co6ibVJAznAaIkqp8huTwlJQCZ016jof/cbN4VW5Yz0=
 gopkg.in/yaml.v3 v3.0.0-20200313102051-9f266ea9e77c h1:dUUwHk2QECo/6vqA44rthZ8ie2QXMNeKRTHCNY2nXvo=
 gopkg.in/yaml.v3 v3.0.0-20200313102051-9f266ea9e77c/go.mod h1:K4uyk7z7BCEPqu6E+C64Yfv1cQ7kz7rIZviUmN+EgEM=

--- a/go.sum
+++ b/go.sum
@@ -1,2 +1,12 @@
+github.com/davecgh/go-spew v1.1.0 h1:ZDRjVQ15GmhC3fiQ8ni8+OwkZQO4DARzQgrnXU1Liz8=
+github.com/davecgh/go-spew v1.1.0/go.mod h1:J7Y8YcW2NihsgmVo/mv3lAwl/skON4iLHjSsI+c5H38=
+github.com/pmezard/go-difflib v1.0.0 h1:4DBwDE0NGyQoBHbLQYPwSUPoCMWR5BEzIk/f1lZbAQM=
+github.com/pmezard/go-difflib v1.0.0/go.mod h1:iKH77koFhYxTK1pcRnkKkqfTogsbg7gZNVY4sRDYZ/4=
 github.com/prashantv/gostub v1.0.0 h1:wTzvgO04xSS3gHuz6Vhuo0/kvWelyJxwNS0IRBPAwGY=
 github.com/prashantv/gostub v1.0.0/go.mod h1:dP1v6T1QzyGJJKFocwAU0lSZKpfjstjH8TlhkEU0on0=
+github.com/stretchr/objx v0.1.0/go.mod h1:HFkY916IF+rwdDfMAkV7OtwuqBVzrE8GR6GFx+wExME=
+github.com/stretchr/testify v1.7.0 h1:nwc3DEeHmmLAfoZucVR881uASk0Mfjw8xYJ99tb5CcY=
+github.com/stretchr/testify v1.7.0/go.mod h1:6Fq8oRcR53rry900zMqJjRRixrwX3KX962/h/Wwjteg=
+gopkg.in/check.v1 v0.0.0-20161208181325-20d25e280405/go.mod h1:Co6ibVJAznAaIkqp8huTwlJQCZ016jof/cbN4VW5Yz0=
+gopkg.in/yaml.v3 v3.0.0-20200313102051-9f266ea9e77c h1:dUUwHk2QECo/6vqA44rthZ8ie2QXMNeKRTHCNY2nXvo=
+gopkg.in/yaml.v3 v3.0.0-20200313102051-9f266ea9e77c/go.mod h1:K4uyk7z7BCEPqu6E+C64Yfv1cQ7kz7rIZviUmN+EgEM=

--- a/iscsi/iscsi.go
+++ b/iscsi/iscsi.go
@@ -279,7 +279,7 @@ func (c *Connector) Connect() (string, error) {
 	// GetISCSIDevices returns all devices if no paths are given
 	if len(devicePaths) < 1 {
 		c.Devices = []Device{}
-	} else if c.Devices, err = GetISCSIDevices(devicePaths); err != nil {
+	} else if c.Devices, err = GetISCSIDevices(devicePaths, true); err != nil {
 		return "", err
 	}
 
@@ -457,10 +457,10 @@ func (c *Connector) IsMultipathEnabled() bool {
 
 // GetSCSIDevices get SCSI devices from device paths
 // It will returns all SCSI devices if no paths are given
-func GetSCSIDevices(devicePaths []string) ([]Device, error) {
+func GetSCSIDevices(devicePaths []string, strict bool) ([]Device, error) {
 	debug.Printf("Getting info about SCSI devices %s.\n", devicePaths)
 
-	deviceInfo, err := lsblk(devicePaths)
+	deviceInfo, err := lsblk(devicePaths, strict)
 	if err != nil {
 		debug.Printf("An error occured while looking info about SCSI devices: %v", err)
 		return nil, err
@@ -471,8 +471,8 @@ func GetSCSIDevices(devicePaths []string) ([]Device, error) {
 
 // GetISCSIDevices get iSCSI devices from device paths
 // It will returns all iSCSI devices if no paths are given
-func GetISCSIDevices(devicePaths []string) (devices []Device, err error) {
-	scsiDevices, err := GetSCSIDevices(devicePaths)
+func GetISCSIDevices(devicePaths []string, strict bool) (devices []Device, err error) {
+	scsiDevices, err := GetSCSIDevices(devicePaths, strict)
 	if err != nil {
 		return
 	}
@@ -488,21 +488,26 @@ func GetISCSIDevices(devicePaths []string) (devices []Device, err error) {
 }
 
 // lsblk execute the lsblk commands
-func lsblk(devicePaths []string) (*deviceInfo, error) {
+func lsblk(devicePaths []string, strict bool) (*deviceInfo, error) {
 	flags := []string{"-J", "-o", "NAME,HCTL,TYPE,TRAN,SIZE"}
 	command := execCommand("lsblk", append(flags, devicePaths...)...)
 	debug.Println(command.String())
 	out, err := command.Output()
 	if err != nil {
 		if ee, ok := err.(*exec.ExitError); ok {
-			return nil, fmt.Errorf("%s, (%v)", strings.Trim(string(ee.Stderr), "\n"), ee)
+			err = fmt.Errorf("%s, (%w)", strings.Trim(string(ee.Stderr), "\n"), ee)
+			if strict || ee.ExitCode() != 64 { // ignore the error if some devices have been found when not strict
+				return nil, err
+			}
+			debug.Printf("lsblk could find only some devices: %v", err)
+		} else {
+			return nil, err
 		}
-		return nil, err
 	}
 
 	var deviceInfo deviceInfo
-	if err = json.Unmarshal(out, &deviceInfo); err != nil {
-		return nil, err
+	if jsonErr := json.Unmarshal(out, &deviceInfo); jsonErr != nil {
+		return nil, jsonErr
 	}
 
 	return &deviceInfo, nil
@@ -603,13 +608,13 @@ func GetConnectorFromFile(filePath string) (*Connector, error) {
 		devicePaths = append(devicePaths, device.GetPath())
 	}
 
-	if devices, err := GetSCSIDevices([]string{c.MountTargetDevice.GetPath()}); err != nil {
+	if devices, err := GetSCSIDevices([]string{c.MountTargetDevice.GetPath()}, false); err != nil {
 		return nil, err
 	} else {
 		c.MountTargetDevice = &devices[0]
 	}
 
-	if c.Devices, err = GetSCSIDevices(devicePaths); err != nil {
+	if c.Devices, err = GetSCSIDevices(devicePaths, false); err != nil {
 		return nil, err
 	}
 

--- a/iscsi/iscsi.go
+++ b/iscsi/iscsi.go
@@ -224,7 +224,11 @@ func getMultipathDevice(devices []Device) (*Device, error) {
 
 	for _, device := range devices {
 		if len(device.Children) != 1 {
-			return nil, fmt.Errorf("device is not mapped to exactly one multipath device: %v", device.Children)
+			multipathdNotRunning := ""
+			if len(device.Children) == 0 {
+				multipathdNotRunning = " (is multipathd running?)"
+			}
+			return nil, fmt.Errorf("device is not mapped to exactly one multipath device%s: %v", multipathdNotRunning, device.Children)
 		}
 		if multipathDevice != nil && device.Children[0].Name != multipathDevice.Name {
 			return nil, fmt.Errorf("devices don't share a common multipath device: %v", devices)

--- a/iscsi/iscsi.go
+++ b/iscsi/iscsi.go
@@ -318,6 +318,14 @@ func (c *Connector) connectTarget(target *TargetInfo, iFace string, iscsiTranspo
 	// to avoid establishing additional sessions to the same target.
 	if _, err := iscsiCmd(append(baseArgs, []string{"-R"}...)...); err != nil {
 		debug.Printf("Failed to rescan session, err: %v", err)
+		if os.IsTimeout(err) {
+			debug.Printf("iscsiadm timeouted, logging out")
+			cmd := execCommand("iscsiadm", append(baseArgs, []string{"-u"}...)...)
+			out, err := cmd.CombinedOutput()
+			if err != nil {
+				return "", fmt.Errorf("could not logout from target: %s", out)
+			}
+		}
 	}
 
 	// create our devicePath that we'll be looking for based on the transport being used

--- a/iscsi/iscsi.go
+++ b/iscsi/iscsi.go
@@ -567,7 +567,7 @@ func RemoveSCSIDevices(devices ...Device) error {
 	if len(errs) > 0 {
 		return errs[0]
 	}
-	debug.Println("Finshed removing SCSI devices.")
+	debug.Println("Finished removing SCSI devices.")
 	return nil
 }
 

--- a/iscsi/iscsi.go
+++ b/iscsi/iscsi.go
@@ -433,7 +433,7 @@ func (c *Connector) DisconnectVolume() error {
 
 // getMountTargetDevice returns the device to be mounted among the configured devices
 func (c *Connector) getMountTargetDevice() (*Device, error) {
-	if c.IsMultipathEnabled() {
+	if len(c.Devices) > 1 {
 		multipathDevice, err := getMultipathDevice(c.Devices)
 		if err != nil {
 			debug.Printf("mount target is not a multipath device: %v", err)
@@ -452,7 +452,7 @@ func (c *Connector) getMountTargetDevice() (*Device, error) {
 
 // IsMultipathEnabled check if multipath is enabled on devices handled by this connector
 func (c *Connector) IsMultipathEnabled() bool {
-	return len(c.Devices) > 1
+	return c.MountTargetDevice.Type == "mpath"
 }
 
 // GetSCSIDevices get SCSI devices from device paths
@@ -499,7 +499,7 @@ func lsblk(devicePaths []string, strict bool) (*deviceInfo, error) {
 			if strict || ee.ExitCode() != 64 { // ignore the error if some devices have been found when not strict
 				return nil, err
 			}
-			debug.Printf("lsblk could find only some devices: %v", err)
+			debug.Printf("Could find only some devices: %v", err)
 		} else {
 			return nil, err
 		}

--- a/iscsi/iscsi.go
+++ b/iscsi/iscsi.go
@@ -20,13 +20,14 @@ import (
 const defaultPort = "3260"
 
 var (
-	debug           *log.Logger
-	execCommand     = exec.Command
-	execWithTimeout = ExecWithTimeout
+	debug              *log.Logger
+	execCommand        = exec.Command
+	execCommandContext = exec.CommandContext
+	execWithTimeout    = ExecWithTimeout
+	osStat             = os.Stat
+	filepathGlob       = filepath.Glob
+	osOpenFile         = os.OpenFile
 )
-
-type statFunc func(string) (os.FileInfo, error)
-type globFunc func(string) ([]string, error)
 
 // iscsiSession contains information avout an iSCSI session
 type iscsiSession struct {
@@ -161,10 +162,6 @@ func getCurrentSessions() ([]iscsiSession, error) {
 
 // waitForPathToExist wait for a file at a path to exists on disk
 func waitForPathToExist(devicePath *string, maxRetries, intervalSeconds uint, deviceTransport string) error {
-	return waitForPathToExistImpl(devicePath, maxRetries, intervalSeconds, deviceTransport, os.Stat, filepath.Glob)
-}
-
-func waitForPathToExistImpl(devicePath *string, maxRetries, intervalSeconds uint, deviceTransport string, osStat statFunc, filepathGlob globFunc) error {
 	if devicePath == nil {
 		return fmt.Errorf("unable to check unspecified devicePath")
 	}
@@ -175,7 +172,7 @@ func waitForPathToExistImpl(devicePath *string, maxRetries, intervalSeconds uint
 			time.Sleep(time.Second * time.Duration(intervalSeconds))
 		}
 
-		if err := pathExistsImpl(devicePath, deviceTransport, osStat, filepathGlob); err == nil {
+		if err := pathExists(devicePath, deviceTransport); err == nil {
 			return nil
 		} else if !os.IsNotExist(err) {
 			return err
@@ -187,10 +184,6 @@ func waitForPathToExistImpl(devicePath *string, maxRetries, intervalSeconds uint
 
 // pathExists checks if a file at a path exists on disk
 func pathExists(devicePath *string, deviceTransport string) error {
-	return pathExistsImpl(devicePath, deviceTransport, os.Stat, filepath.Glob)
-}
-
-func pathExistsImpl(devicePath *string, deviceTransport string, osStat statFunc, filepathGlob globFunc) error {
 	if deviceTransport == "tcp" {
 		_, err := osStat(*devicePath)
 		if err != nil {
@@ -423,11 +416,7 @@ func (c *Connector) DisconnectVolume() error {
 	} else {
 		devicePath := c.MountTargetDevice.GetPath()
 		debug.Printf("Removing normal device in path %s.\n", devicePath)
-		device, err := GetISCSIDevice(devicePath)
-		if err != nil {
-			return err
-		}
-		if err = RemoveSCSIDevices(*device); err != nil {
+		if err := RemoveSCSIDevices(*c.MountTargetDevice); err != nil {
 			return err
 		}
 	}
@@ -458,18 +447,6 @@ func (c *Connector) getMountTargetDevice() (*Device, error) {
 // IsMultipathEnabled check if multipath is enabled on devices handled by this connector
 func (c *Connector) IsMultipathEnabled() bool {
 	return len(c.Devices) > 1
-}
-
-// GetISCSIDevice get an SCSI device from a device name
-func GetISCSIDevice(deviceName string) (*Device, error) {
-	iscsiDevices, err := GetISCSIDevices([]string{deviceName})
-	if err != nil {
-		return nil, err
-	}
-	if len(iscsiDevices) == 0 {
-		return nil, fmt.Errorf("device %q not found", deviceName)
-	}
-	return &iscsiDevices[0], nil
 }
 
 // GetSCSIDevices get SCSI devices from device paths
@@ -512,7 +489,7 @@ func GetISCSIDevices(devicePaths []string) (devices []Device, err error) {
 
 // lsblk execute the lsblk commands
 func lsblk(flags string, devicePaths []string) ([]byte, error) {
-	out, err := exec.Command("lsblk", append([]string{flags}, devicePaths...)...).CombinedOutput()
+	out, err := execCommand("lsblk", append([]string{flags}, devicePaths...)...).CombinedOutput()
 	debug.Printf("lsblk %s %s", flags, strings.Join(devicePaths, " "))
 	if err != nil {
 		return nil, fmt.Errorf("lsblk: %s", string(out))
@@ -526,7 +503,7 @@ func writeInSCSIDeviceFile(hctl string, file string, content string) error {
 	filename := filepath.Join("/sys/class/scsi_device", hctl, "device", file)
 	debug.Printf("Write %q in %q.\n", content, filename)
 
-	f, err := os.OpenFile(filename, os.O_TRUNC|os.O_WRONLY, 0200)
+	f, err := osOpenFile(filename, os.O_TRUNC|os.O_WRONLY, 0200)
 	if err != nil {
 		debug.Printf("Error while opening file %v: %v\n", filename, err)
 		return err
@@ -549,7 +526,7 @@ func RemoveSCSIDevices(devices ...Device) error {
 	for _, device := range devices {
 		debug.Printf("Flush SCSI device %v.\n", device.Name)
 		if err := device.Exists(); err == nil {
-			out, err := exec.Command("blockdev", "--flushbufs", device.GetPath()).CombinedOutput()
+			out, err := execCommand("blockdev", "--flushbufs", device.GetPath()).CombinedOutput()
 			if err != nil {
 				debug.Printf("Command 'blockdev --flushbufs %s' did not succeed to flush the device: %v\n", device.GetPath(), err)
 				return errors.New(string(out))
@@ -617,7 +594,7 @@ func GetConnectorFromFile(filePath string) (*Connector, error) {
 
 // Exists check if the device exists at its path and returns an error otherwise
 func (d *Device) Exists() error {
-	_, err := os.Stat(d.GetPath())
+	_, err := osStat(d.GetPath())
 	return err
 }
 

--- a/iscsi/iscsi_test.go
+++ b/iscsi/iscsi_test.go
@@ -248,7 +248,7 @@ func Test_extractTransportName(t *testing.T) {
 
 func Test_sessionExists(t *testing.T) {
 	fakeOutput := "tcp: [4] 192.168.1.107:3260,1 iqn.2010-10.org.openstack:volume-eb393993-73d0-4e39-9ef4-b5841e244ced (non-flash)\n"
-	defer gostub.Stub(&execCommand, makeFakeExecCommand(0, fakeOutput)).Reset()
+	defer gostub.Stub(&execWithTimeout, makeFakeExecWithTimeout(false, []byte(fakeOutput), nil)).Reset()
 
 	type args struct {
 		tgtPortal string

--- a/iscsi/iscsi_test.go
+++ b/iscsi/iscsi_test.go
@@ -668,7 +668,8 @@ func TestConnectorPersistance(t *testing.T) {
 	}
 	c := Connector{
 		VolumeName:        "fake volume name",
-		Targets:           []TargetInfo{},
+		TargetIqn:         "fake target iqn",
+		TargetPortals:     []string{},
 		Lun:               42,
 		AuthType:          "fake auth type",
 		DiscoverySecrets:  secret,

--- a/iscsi/iscsi_test.go
+++ b/iscsi/iscsi_test.go
@@ -272,7 +272,6 @@ func Test_sessionExists(t *testing.T) {
 }
 
 func Test_DisconnectNormalVolume(t *testing.T) {
-
 	tmpDir, err := ioutil.TempDir("", "")
 	if err != nil {
 		t.Errorf("can not create temp directory: %v", err)

--- a/iscsi/iscsi_test.go
+++ b/iscsi/iscsi_test.go
@@ -89,6 +89,7 @@ var testExecWithTimeoutError error
 var mockedExitStatus = 0
 var mockedStdout string
 
+var sysBlockPath = "/sys/block"
 var normalDevice = "sda"
 var multipathDevice = "dm-1"
 var slaves = []string{"sdb", "sdc"}

--- a/iscsi/iscsiadm.go
+++ b/iscsi/iscsiadm.go
@@ -36,6 +36,7 @@ func (e *CmdError) Error() string {
 
 func iscsiCmd(args ...string) (string, error) {
 	cmd := execCommand("iscsiadm", args...)
+	debug.Printf("Run iscsiadm command: %s", strings.Join(append([]string{"iscsiadm"}, args...), " "))
 	var stdout bytes.Buffer
 	var iscsiadmError error
 	cmd.Stdout = &stdout
@@ -91,7 +92,7 @@ func ShowInterface(iface string) (string, error) {
 func CreateDBEntry(tgtIQN, portal, iFace string, discoverySecrets, sessionSecrets Secrets) error {
 	debug.Println("Begin CreateDBEntry...")
 	baseArgs := []string{"-m", "node", "-T", tgtIQN, "-p", portal}
-	_, err := iscsiCmd(append(baseArgs, []string{"-I", iFace, "-o", "new"}...)...)
+	_, err := iscsiCmd(append(baseArgs, "-I", iFace, "-o", "new")...)
 	if err != nil {
 		return err
 	}

--- a/iscsi/iscsiadm.go
+++ b/iscsi/iscsiadm.go
@@ -181,29 +181,25 @@ func GetSessions() (string, error) {
 
 // Login performs an iscsi login for the specified target
 func Login(tgtIQN, portal string) error {
+	debug.Println("Begin Login...")
 	baseArgs := []string{"-m", "node", "-T", tgtIQN, "-p", portal}
-	_, err := iscsiCmd(append(baseArgs, []string{"-l"}...)...)
-	if err != nil {
+	if _, err := iscsiCmd(append(baseArgs, []string{"-l"}...)...); err != nil {
 		//delete the node record from database
 		iscsiCmd(append(baseArgs, []string{"-o", "delete"}...)...)
 		return fmt.Errorf("failed to sendtargets to portal %s, err: %v", portal, err)
 	}
-	return err
-}
-
-// Logout logs out the specified target, if the target is not logged in it's not considered an error
-func Logout(tgtIQN string, portals []string) error {
-	debug.Println("Begin Logout...")
-	baseArgs := []string{"-m", "node", "-T", tgtIQN}
-	for _, p := range portals {
-		debug.Printf("attempting logout for portal: %s", p)
-		args := append(baseArgs, []string{"-p", p, "-u"}...)
-		iscsiCmd(args...)
-	}
 	return nil
 }
 
-// DeleteDBEntry deletes the iscsi db entry fo rthe specified target
+// Logout logs out the specified target
+func Logout(tgtIQN, portal string) error {
+	debug.Println("Begin Logout...")
+	args := []string{"-m", "node", "-T", tgtIQN, "-p", portal, "-u"}
+	iscsiCmd(args...)
+	return nil
+}
+
+// DeleteDBEntry deletes the iscsi db entry for the specified target
 func DeleteDBEntry(tgtIQN string) error {
 	debug.Println("Begin DeleteDBEntry...")
 	args := []string{"-m", "node", "-T", tgtIQN, "-o", "delete"}

--- a/iscsi/iscsiadm_test.go
+++ b/iscsi/iscsiadm_test.go
@@ -1,9 +1,12 @@
 package iscsi
 
-import "testing"
+import (
+	"testing"
+
+	"github.com/prashantv/gostub"
+)
 
 func TestDiscovery(t *testing.T) {
-	execCommand = fakeExecCommand
 	tests := map[string]struct {
 		tgtPortal        string
 		iface            string
@@ -63,8 +66,7 @@ iscsiadm: Could not perform SendTargets discovery.\n`,
 
 	for name, tt := range tests {
 		t.Run(name, func(t *testing.T) {
-			mockedExitStatus = tt.mockedExitStatus
-			mockedStdout = tt.mockedStdout
+			defer gostub.Stub(&execCommand, makeFakeExecCommand(tt.mockedExitStatus, tt.mockedStdout)).Reset()
 			err := Discoverydb(tt.tgtPortal, tt.iface, tt.discoverySecret, tt.chapDiscovery)
 			if (err != nil) != tt.wantErr {
 				t.Errorf("Discoverydb() error = %v, wantErr %v", err, tt.wantErr)
@@ -75,7 +77,6 @@ iscsiadm: Could not perform SendTargets discovery.\n`,
 }
 
 func TestCreateDBEntry(t *testing.T) {
-	execCommand = fakeExecCommand
 	tests := map[string]struct {
 		tgtPortal        string
 		tgtIQN           string
@@ -115,8 +116,7 @@ func TestCreateDBEntry(t *testing.T) {
 
 	for name, tt := range tests {
 		t.Run(name, func(t *testing.T) {
-			mockedExitStatus = tt.mockedExitStatus
-			mockedStdout = tt.mockedStdout
+			defer gostub.Stub(&execCommand, makeFakeExecCommand(tt.mockedExitStatus, tt.mockedStdout)).Reset()
 			err := CreateDBEntry(tt.tgtIQN, tt.tgtPortal, tt.iface, tt.discoverySecret, tt.sessionSecret)
 			if (err != nil) != tt.wantErr {
 				t.Errorf("CreateDBEntry() error = %v, wantErr %v", err, tt.wantErr)

--- a/iscsi/multipath.go
+++ b/iscsi/multipath.go
@@ -2,25 +2,20 @@ package iscsi
 
 import (
 	"context"
+	"encoding/json"
 	"os"
 	"os/exec"
-	"path/filepath"
 	"time"
-	"encoding/json"
 )
-
-var sysBlockPath = "/sys/block"
-var sysScsiPath = "/sys/class/scsi_device"
-var devPath = "/dev"
 
 type multipathDeviceMap struct {
 	Map multipathMap `json:"map"`
 }
 
 type multipathMap struct {
-	Name string `json:"name"`
-	Uuid string `json:"uuid"`
-	Sysfs string `json:"sysfs"`
+	Name       string      `json:"name"`
+	UUID       string      `json:"uuid"`
+	Sysfs      string      `json:"sysfs"`
 	PathGroups []pathGroup `json:"path_groups"`
 }
 
@@ -32,6 +27,7 @@ type path struct {
 	Device string `json:"dev"`
 }
 
+// ExecWithTimeout execute a command with a timeout and returns an error if timeout is excedeed
 func ExecWithTimeout(command string, args []string, timeout time.Duration) ([]byte, error) {
 	debug.Printf("Executing command '%v' with args: '%v'.\n", command, args)
 
@@ -53,8 +49,6 @@ func ExecWithTimeout(command string, args []string, timeout time.Duration) ([]by
 		return nil, ctx.Err()
 	}
 
-	// If there's no context error, we know the command completed (or errored).
-	debug.Printf("Output from command: %s", string(out))
 	if err != nil {
 		debug.Printf("Non-zero exit code: %s\n", err)
 	}
@@ -64,7 +58,7 @@ func ExecWithTimeout(command string, args []string, timeout time.Duration) ([]by
 }
 
 func getMultipathMap(device string) (*multipathDeviceMap, error) {
-	debug.Printf("Getting multipath map for device %s.\n", device[1:])
+	debug.Printf("Getting multipath map for device %s.\n", device)
 
 	cmd := exec.Command("multipathd", "show", "map", device[1:], "json")
 	out, err := cmd.Output()
@@ -74,8 +68,11 @@ func getMultipathMap(device string) (*multipathDeviceMap, error) {
 		return nil, err
 	}
 
-	var deviceMap multipathDeviceMap;
-	json.Unmarshal(out, &deviceMap)
+	var deviceMap multipathDeviceMap
+	err = json.Unmarshal(out, &deviceMap)
+	if err != nil {
+		return nil, err
+	}
 	return &deviceMap, nil
 }
 
@@ -91,40 +88,23 @@ func (deviceMap *multipathDeviceMap) GetSlaves() []string {
 	return slaves
 }
 
-// GetScsiDevicesFromMultipathDevice gets all ScsiDevice for multipath device dm-x
-func GetScsiDevicesFromMultipathDevice(device string) ([]string, error) {
-	debug.Printf("Getting all slaves for multipath device %s.\n", device)
-
-	deviceMap, err := getMultipathMap(device)
-
-	if err != nil {
-		debug.Printf("An error occured while looking for slaves: %v\n", err)
-		return nil, err
-	}
-
-	slaves := deviceMap.GetSlaves()
-
-	debug.Printf("Found slaves: %v.\n", slaves)
-	return slaves, nil
-}
-
 // FlushMultipathDevice flushes a multipath device dm-x with command multipath -f /dev/dm-x
-func FlushMultipathDevice(device string) error {
-	debug.Printf("Flushing multipath device '%v'.\n", device)
+func FlushMultipathDevice(device *Device) error {
+	devicePath := device.GetPath()
+	debug.Printf("Flushing multipath device '%v'.\n", devicePath)
 
-	fullDevice := filepath.Join(devPath, device)
 	timeout := 5 * time.Second
-	_, err := execWithTimeout("multipath", []string{"-f", fullDevice}, timeout)
+	_, err := execWithTimeout("multipath", []string{"-f", devicePath}, timeout)
 
 	if err != nil {
-		if _, e := os.Stat(fullDevice); os.IsNotExist(e) {
-			debug.Printf("Multipath device %v was deleted.\n", device)
+		if _, e := os.Stat(devicePath); os.IsNotExist(e) {
+			debug.Printf("Multipath device %v has been removed.\n", devicePath)
 		} else {
-			debug.Printf("Command 'multipath -f %v' did not succeed to delete the device: %v\n", fullDevice, err)
+			debug.Printf("Command 'multipath -f %v' did not succeed to delete the device: %v\n", devicePath, err)
 			return err
 		}
 	}
 
-	debug.Printf("Finshed flushing multipath device %v.\n", device)
+	debug.Printf("Finshed flushing multipath device %v.\n", devicePath)
 	return nil
 }

--- a/iscsi/multipath.go
+++ b/iscsi/multipath.go
@@ -116,3 +116,14 @@ func FlushMultipathDevice(device *Device) error {
 	debug.Printf("Finshed flushing multipath device %v.\n", devicePath)
 	return nil
 }
+
+// ResizeMultipathDevice resize a multipath device based on its underlying devices
+func ResizeMultipathDevice(device *Device) error {
+	debug.Printf("Resizing multipath device %s\n", device.GetPath())
+
+	if output, err := exec.Command("multipathd", "resize", "map", device.Name).CombinedOutput(); err != nil {
+		return fmt.Errorf("could not resize multipath device: %s (%v)", output, err)
+	}
+
+	return nil
+}

--- a/iscsi/multipath.go
+++ b/iscsi/multipath.go
@@ -38,7 +38,7 @@ func ExecWithTimeout(command string, args []string, timeout time.Duration) ([]by
 	defer cancel()
 
 	// Create command with context
-	cmd := exec.CommandContext(ctx, command, args...)
+	cmd := execCommandContext(ctx, command, args...)
 
 	// This time we can simply use Output() to get the result.
 	out, err := cmd.Output()
@@ -65,7 +65,7 @@ func ExecWithTimeout(command string, args []string, timeout time.Duration) ([]by
 func getMultipathMap(device string) (*multipathDeviceMap, error) {
 	debug.Printf("Getting multipath map for device %s.\n", device)
 
-	cmd := exec.Command("multipathd", "show", "map", device[1:], "json")
+	cmd := execCommand("multipathd", "show", "map", device[1:], "json")
 	out, err := cmd.CombinedOutput()
 	// debug.Printf(string(out))
 	if err != nil {
@@ -102,7 +102,7 @@ func FlushMultipathDevice(device *Device) error {
 	_, err := execWithTimeout("multipath", []string{"-f", devicePath}, timeout)
 
 	if err != nil {
-		if _, e := os.Stat(devicePath); os.IsNotExist(e) {
+		if _, e := osStat(devicePath); os.IsNotExist(e) {
 			debug.Printf("Multipath device %v has been removed.\n", devicePath)
 		} else {
 			if strings.Contains(err.Error(), "map in use") {
@@ -121,7 +121,7 @@ func FlushMultipathDevice(device *Device) error {
 func ResizeMultipathDevice(device *Device) error {
 	debug.Printf("Resizing multipath device %s\n", device.GetPath())
 
-	if output, err := exec.Command("multipathd", "resize", "map", device.Name).CombinedOutput(); err != nil {
+	if output, err := execCommand("multipathd", "resize", "map", device.Name).CombinedOutput(); err != nil {
 		return fmt.Errorf("could not resize multipath device: %s (%v)", output, err)
 	}
 

--- a/iscsi/multipath_test.go
+++ b/iscsi/multipath_test.go
@@ -1,0 +1,79 @@
+package iscsi
+
+import (
+	"context"
+	"os/exec"
+	"testing"
+	"time"
+
+	"github.com/prashantv/gostub"
+	"github.com/stretchr/testify/assert"
+)
+
+func TestExecWithTimeout(t *testing.T) {
+	tests := map[string]struct {
+		mockedStdout     string
+		mockedExitStatus int
+		wantTimeout      bool
+	}{
+		"Success": {
+			mockedStdout:     "some output",
+			mockedExitStatus: 0,
+			wantTimeout:      false,
+		},
+		"WithError": {
+			mockedStdout:     "some\noutput",
+			mockedExitStatus: 1,
+			wantTimeout:      false,
+		},
+		"WithTimeout": {
+			mockedStdout:     "",
+			mockedExitStatus: 0,
+			wantTimeout:      true,
+		},
+		"WithTimeoutAndOutput": {
+			mockedStdout:     "should not be returned",
+			mockedExitStatus: 0,
+			wantTimeout:      true,
+		},
+		"WithTimeoutAndError": {
+			mockedStdout:     "",
+			mockedExitStatus: 1,
+			wantTimeout:      true,
+		},
+	}
+	for name, tt := range tests {
+		t.Run(name, func(t *testing.T) {
+			assert := assert.New(t)
+
+			timeout := time.Second
+			if tt.wantTimeout {
+				timeout = time.Millisecond * 50
+			}
+
+			defer gostub.Stub(&execCommandContext, func(ctx context.Context, command string, args ...string) *exec.Cmd {
+				if tt.wantTimeout {
+					time.Sleep(timeout + time.Millisecond*10)
+				}
+				return makeFakeExecCommandContext(tt.mockedExitStatus, tt.mockedStdout)(ctx, command, args...)
+			}).Reset()
+
+			out, err := ExecWithTimeout("dummy", []string{}, timeout)
+
+			if tt.wantTimeout || tt.mockedExitStatus != 0 {
+				assert.NotNil(err)
+				if tt.wantTimeout {
+					assert.Equal(context.DeadlineExceeded, err)
+				}
+			} else {
+				assert.Nil(err)
+			}
+
+			if tt.wantTimeout {
+				assert.Equal("", string(out))
+			} else {
+				assert.Equal(tt.mockedStdout, string(out))
+			}
+		})
+	}
+}


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:

1. If this is your first time, please read our contributor guidelines: https://git.k8s.io/community/contributors/guide#your-first-contribution and developer guide https://git.k8s.io/community/contributors/devel/development.md#development-guide
2. Follow the instructions for writing a release note: https://git.k8s.io/community/contributors/guide/release-notes.md
3. If the PR is unfinished, see how to mark it: https://git.k8s.io/community/contributors/guide/pull-requests.md#marking-unfinished-pull-requests
-->

**What type of PR is this?**

/kind cleanup

**What this PR does / why we need it**:

This PR fix some stability issues related to multipathd by adding multiple consistency checks and prevent filesystem corruption. It also adds a lot of tests.

**Which issue(s) this PR fixes**:

**Special notes for your reviewer**:

This code is already being used in production by [enix/san-iscsi-csi](https://github.com/enix/san-iscsi-csi) and [Seagate/seagate-exos-x-csi](https://github.com/Seagate/seagate-exos-x-csi).

**Does this PR introduce a user-facing change?**:
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".
-->
```release-note
connector.Multipath has been removed, multipath is automatically used if multiple targets are given.
connector.TargetIqn and connector.TargetPortals has been replace by connector.Targets.
Connect is now a member function of connector.
```
