### PR TITLE
Do error checking and error wrapping in the connector functions.

### DIFF
--- a/iscsi/iscsi.go
+++ b/iscsi/iscsi.go
@@ -293,7 +293,10 @@ func (c *Connector) Connect() (string, error) {
 	c.MountTargetDevice = mountTargetDevice
 	if err != nil {
 		debug.Printf("Connect failed: %v", err)
-		RemoveSCSIDevices(c.Devices...)
+		err := RemoveSCSIDevices(c.Devices...)
+		if err != nil {
+			return "", err
+		}
 		c.MountTargetDevice = nil
 		c.Devices = []Device{}
 		return "", err
@@ -392,7 +395,10 @@ func (c *Connector) discoverTarget(targetIqn string, iFace string, portal string
 func Disconnect(targetIqn string, targets []string) {
 	for _, target := range targets {
 		targetPortal := strings.Split(target, ":")[0]
-		Logout(targetIqn, targetPortal)
+		err := Logout(targetIqn, targetPortal)
+		if err != nil {
+			return
+		}
 	}
 
 	deleted := map[string]bool{}
@@ -400,7 +406,10 @@ func Disconnect(targetIqn string, targets []string) {
 		return
 	}
 	deleted[targetIqn] = true
-	DeleteDBEntry(targetIqn)
+	err := DeleteDBEntry(targetIqn)
+	if err != nil {
+		return
+	}
 }
 
 // Disconnect performs a disconnect operation from an appliance.
@@ -669,7 +678,9 @@ func GetConnectorFromFile(filePath string) (*Connector, error) {
 	for _, device := range c.Devices {
 		devicePaths = append(devicePaths, device.GetPath())
 	}
-
+	if c.MountTargetDevice == nil {
+		return nil, fmt.Errorf("mountTargetDevice in the connector is nil")
+	}
 	if devices, err := GetSCSIDevices([]string{c.MountTargetDevice.GetPath()}, false); err != nil {
 		return nil, err
 	} else {

--- a/iscsi/iscsiadm.go
+++ b/iscsi/iscsiadm.go
@@ -65,12 +65,18 @@ func CreateDBEntry(tgtIQN, portal, iFace string, discoverySecrets, sessionSecret
 
 	if discoverySecrets.SecretsType == "chap" {
 		debug.Printf("Setting CHAP Discovery...")
-		createCHAPEntries(baseArgs, discoverySecrets, true)
+		err := createCHAPEntries(baseArgs, discoverySecrets, true)
+		if err != nil {
+			return err
+		}
 	}
 
 	if sessionSecrets.SecretsType == "chap" {
 		debug.Printf("Setting CHAP Session...")
-		createCHAPEntries(baseArgs, sessionSecrets, false)
+		err := createCHAPEntries(baseArgs, sessionSecrets, false)
+		if err != nil {
+			return err
+		}
 	}
 
 	return err

--- a/iscsi/multipath.go
+++ b/iscsi/multipath.go
@@ -2,20 +2,13 @@ package iscsi
 
 import (
 	"context"
+	"errors"
 	"fmt"
 	"os"
 	"os/exec"
 	"strings"
 	"time"
 )
-
-type pathGroup struct {
-	Paths []path `json:"paths"`
-}
-
-type path struct {
-	Device string `json:"dev"`
-}
 
 // ExecWithTimeout execute a command with a timeout and returns an error if timeout is excedeed
 func ExecWithTimeout(command string, args []string, timeout time.Duration) ([]byte, error) {
@@ -35,13 +28,14 @@ func ExecWithTimeout(command string, args []string, timeout time.Duration) ([]by
 	// We want to check the context error to see if the timeout was executed.
 	// The error returned by cmd.Output() will be OS specific based on what
 	// happens when a process is killed.
-	if ctx.Err() == context.DeadlineExceeded {
+	if errors.Is(ctx.Err(), context.DeadlineExceeded) {
 		debug.Printf("Command '%s' timeout reached.\n", command)
 		return nil, ctx.Err()
 	}
 
 	if err != nil {
-		if ee, ok := err.(*exec.ExitError); ok {
+		var ee *exec.ExitError
+		if ok := errors.Is(err, ee); ok {
 			debug.Printf("Non-zero exit code: %s\n", err)
 			err = fmt.Errorf("%s", ee.Stderr)
 		}


### PR DESCRIPTION
/kind cleanup



-->
```release-note-none

```
