### PR TITLE
refactor: Switch to using klog structured logging, multipath discover…

### DIFF
--- a/README.md
+++ b/README.md
@@ -17,7 +17,7 @@ golang libs.  This may prove to not be ideal, and may be changed over time, but 
 
 ## Logging and Debug
 
-This library uses klog/v2 with structured and contextual logging to produce InfoS and ErrorS log entries. A caller
+This library uses klog/v2 with structured and contextual logging to produce Info and Error log entries. A caller
 can change the verbosity level by using the command line option of "-v=#" and using "-v=0" will not produce any
 log entries. To increase the verbosity of the log entries, use "-v=2". External functions require context.Context
 and the logger is extracted from the context using klog.FromContext(ctx), and then a logger pointer is passed around

--- a/README.md
+++ b/README.md
@@ -17,14 +17,18 @@ golang libs.  This may prove to not be ideal, and may be changed over time, but 
 
 ## Logging and Debug
 
-By default the library uses klog and structured logging to produce InfoS and ErrorS log entries. A caller can replace
-the default io.Writer with their own by using the provided function:
+This library uses klog/v2 with structured and contextual logging to produce InfoS and ErrorS log entries. A caller
+can change the verbosity level by using the command line option of "-v=#" and using "-v=0" will not produce any
+log entries. To increase the verbosity of the log entries, use "-v=2". External functions require context.Context
+and the logger is extracted from the context using klog.FromContext(ctx), and then a logger pointer is passed around
+to internal functions that rely on InfoS and ErrorS calls.
 
-```
-func EnableDebugLogging(writer io.Writer)
-```
+## External Binary Dependencies
 
-This direct logging to the provided io.Writer and include the response of every iscsiadm command issued.
+This library relies on the following operating system executables:
+* iscsiadm - Open-iscsi administration utility.
+* multipath - Device mapper target autoconfig.
+* multipathd - Multipath daemon.
 
 ## Intended Usage
 

--- a/README.md
+++ b/README.md
@@ -17,20 +17,19 @@ golang libs.  This may prove to not be ideal, and may be changed over time, but 
 
 ## Logging and Debug
 
-By default the library does not provide any logging, but provides an error message that includes any messages from
-iscsiadm as well as exit-codes.  In the event that you need to debug the library, we provide a function:
+By default the library uses klog and structured logging to produce InfoS and ErrorS log entries. A caller can replace
+the default io.Writer with their own by using the provided function:
 
 ```
 func EnableDebugLogging(writer io.Writer)
 ```
 
-This will turn on verbose logging directed to the provided io.Writer and include the response of every iscsiadm command
-issued.
+This direct logging to the provided io.Writer and include the response of every iscsiadm command issued.
 
 ## Intended Usage
 
-Curently the intended usage of this library is simply to provide a golang package to standardize how plugins are implementing
-iscsi connect and disconnect.  It's not intended to be  a "service", although that's a possible next step.  It's currenty been
+Currently the intended usage of this library is simply to provide a golang package to standardize how plugins are implementing
+iscsi connect and disconnect.  It's not intended to be  a "service", although that's a possible next step.  It's currently been
 used for plugins where iscsid is installed in containers only, as well as designs where it uses the nodes iscsid.  Each of these
 approaches has their own pros and cons.  Currently, it's up to the plugin author to determine which model suits them best
 and to deploy their node plugin appropriately.

--- a/go.mod
+++ b/go.mod
@@ -1,8 +1,17 @@
-module github.com/kubernetes-csi/csi-lib-iscsi
+module github.com/Seagate/csi-lib-iscsi
 
-go 1.15
+go 1.18
 
 require (
+	github.com/kubernetes-csi/csi-lib-iscsi v0.0.0-20220106022228-366f3190694e
 	github.com/prashantv/gostub v1.0.0
 	github.com/stretchr/testify v1.7.0
+	k8s.io/klog/v2 v2.60.1
+)
+
+require (
+	github.com/davecgh/go-spew v1.1.0 // indirect
+	github.com/go-logr/logr v1.2.0 // indirect
+	github.com/pmezard/go-difflib v1.0.0 // indirect
+	gopkg.in/yaml.v3 v3.0.0-20200313102051-9f266ea9e77c // indirect
 )

--- a/go.mod
+++ b/go.mod
@@ -1,4 +1,4 @@
-module github.com/Seagate/csi-lib-iscsi
+module github.com/kubernetes-csi/csi-lib-iscsi
 
 go 1.18
 

--- a/go.mod
+++ b/go.mod
@@ -3,6 +3,7 @@ module github.com/kubernetes-csi/csi-lib-iscsi
 go 1.18
 
 require (
+	github.com/go-logr/logr v1.2.0
 	github.com/prashantv/gostub v1.0.0
 	github.com/stretchr/testify v1.7.0
 	k8s.io/klog/v2 v2.60.1
@@ -10,7 +11,6 @@ require (
 
 require (
 	github.com/davecgh/go-spew v1.1.0 // indirect
-	github.com/go-logr/logr v1.2.0 // indirect
 	github.com/pmezard/go-difflib v1.0.0 // indirect
 	gopkg.in/yaml.v3 v3.0.0-20200313102051-9f266ea9e77c // indirect
 )

--- a/go.mod
+++ b/go.mod
@@ -3,7 +3,6 @@ module github.com/kubernetes-csi/csi-lib-iscsi
 go 1.18
 
 require (
-	github.com/kubernetes-csi/csi-lib-iscsi v0.0.0-20220106022228-366f3190694e
 	github.com/prashantv/gostub v1.0.0
 	github.com/stretchr/testify v1.7.0
 	k8s.io/klog/v2 v2.60.1

--- a/go.sum
+++ b/go.sum
@@ -1,5 +1,9 @@
 github.com/davecgh/go-spew v1.1.0 h1:ZDRjVQ15GmhC3fiQ8ni8+OwkZQO4DARzQgrnXU1Liz8=
 github.com/davecgh/go-spew v1.1.0/go.mod h1:J7Y8YcW2NihsgmVo/mv3lAwl/skON4iLHjSsI+c5H38=
+github.com/go-logr/logr v1.2.0 h1:QK40JKJyMdUDz+h+xvCsru/bJhvG0UxvePV0ufL/AcE=
+github.com/go-logr/logr v1.2.0/go.mod h1:jdQByPbusPIv2/zmleS9BjJVeZ6kBagPoEUsqbVz/1A=
+github.com/kubernetes-csi/csi-lib-iscsi v0.0.0-20220106022228-366f3190694e h1:krLbHxbBpekmhDPqQoV1IvMlajXKPumDBIfbW0e4zbs=
+github.com/kubernetes-csi/csi-lib-iscsi v0.0.0-20220106022228-366f3190694e/go.mod h1:c/keGS6bErOzLrFyNgafdDWT6h72v2XQiA/p2R7yghU=
 github.com/pmezard/go-difflib v1.0.0 h1:4DBwDE0NGyQoBHbLQYPwSUPoCMWR5BEzIk/f1lZbAQM=
 github.com/pmezard/go-difflib v1.0.0/go.mod h1:iKH77koFhYxTK1pcRnkKkqfTogsbg7gZNVY4sRDYZ/4=
 github.com/prashantv/gostub v1.0.0 h1:wTzvgO04xSS3gHuz6Vhuo0/kvWelyJxwNS0IRBPAwGY=
@@ -11,3 +15,5 @@ gopkg.in/check.v1 v0.0.0-20161208181325-20d25e280405 h1:yhCVgyC4o1eVCa2tZl7eS0r+
 gopkg.in/check.v1 v0.0.0-20161208181325-20d25e280405/go.mod h1:Co6ibVJAznAaIkqp8huTwlJQCZ016jof/cbN4VW5Yz0=
 gopkg.in/yaml.v3 v3.0.0-20200313102051-9f266ea9e77c h1:dUUwHk2QECo/6vqA44rthZ8ie2QXMNeKRTHCNY2nXvo=
 gopkg.in/yaml.v3 v3.0.0-20200313102051-9f266ea9e77c/go.mod h1:K4uyk7z7BCEPqu6E+C64Yfv1cQ7kz7rIZviUmN+EgEM=
+k8s.io/klog/v2 v2.60.1 h1:VW25q3bZx9uE3vvdL6M8ezOX79vA2Aq1nEWLqNQclHc=
+k8s.io/klog/v2 v2.60.1/go.mod h1:y1WjHnz7Dj687irZUWR/WLkLc5N1YHtjLdmgWjndZn0=

--- a/go.sum
+++ b/go.sum
@@ -2,8 +2,6 @@ github.com/davecgh/go-spew v1.1.0 h1:ZDRjVQ15GmhC3fiQ8ni8+OwkZQO4DARzQgrnXU1Liz8
 github.com/davecgh/go-spew v1.1.0/go.mod h1:J7Y8YcW2NihsgmVo/mv3lAwl/skON4iLHjSsI+c5H38=
 github.com/go-logr/logr v1.2.0 h1:QK40JKJyMdUDz+h+xvCsru/bJhvG0UxvePV0ufL/AcE=
 github.com/go-logr/logr v1.2.0/go.mod h1:jdQByPbusPIv2/zmleS9BjJVeZ6kBagPoEUsqbVz/1A=
-github.com/kubernetes-csi/csi-lib-iscsi v0.0.0-20220106022228-366f3190694e h1:krLbHxbBpekmhDPqQoV1IvMlajXKPumDBIfbW0e4zbs=
-github.com/kubernetes-csi/csi-lib-iscsi v0.0.0-20220106022228-366f3190694e/go.mod h1:c/keGS6bErOzLrFyNgafdDWT6h72v2XQiA/p2R7yghU=
 github.com/pmezard/go-difflib v1.0.0 h1:4DBwDE0NGyQoBHbLQYPwSUPoCMWR5BEzIk/f1lZbAQM=
 github.com/pmezard/go-difflib v1.0.0/go.mod h1:iKH77koFhYxTK1pcRnkKkqfTogsbg7gZNVY4sRDYZ/4=
 github.com/prashantv/gostub v1.0.0 h1:wTzvgO04xSS3gHuz6Vhuo0/kvWelyJxwNS0IRBPAwGY=

--- a/iscsi/iscsi.go
+++ b/iscsi/iscsi.go
@@ -6,7 +6,6 @@ import (
 	"fmt"
 	"io"
 	"io/ioutil"
-	"log"
 	"os"
 	"os/exec"
 	"path/filepath"
@@ -15,12 +14,13 @@ import (
 	"strings"
 	"syscall"
 	"time"
+
+	"k8s.io/klog/v2"
 )
 
 const defaultPort = "3260"
 
 var (
-	debug              *log.Logger
 	execCommand        = exec.Command
 	execCommandContext = exec.CommandContext
 	execWithTimeout    = ExecWithTimeout
@@ -78,15 +78,17 @@ type Connector struct {
 	DoCHAPDiscovery bool `json:"do_chap_discovery"`
 }
 
+var version string = "1.0.0"
+
 func init() {
-	// by default we don't log anything, EnableDebugLogging() can turn on some tracing
-	debug = log.New(ioutil.Discard, "", 0)
+	// By default we produce info and error log entries which can be redirected using EnableDebugLogging()
+	klog.InfoS("[] csi-lib-iscsi", "version", version)
 }
 
-// EnableDebugLogging provides a mechanism to turn on debug logging for this package
-// output is written to the provided io.Writer
+// EnableDebugLogging provides a mechanism to allow a caller to set their own io.Writer
 func EnableDebugLogging(writer io.Writer) {
-	debug = log.New(writer, "DEBUG: ", log.Ldate|log.Ltime|log.Lshortfile)
+	klog.InfoS("Enable a caller's io.Writer")
+	klog.SetOutput(writer)
 }
 
 // parseSession takes the raw stdout from the iscsiadm -m session command and encodes it into an iSCSI session type
@@ -166,7 +168,7 @@ func waitForPathToExist(devicePath *string, maxRetries, intervalSeconds uint, de
 
 	for i := uint(0); i <= maxRetries; i++ {
 		if i != 0 {
-			debug.Printf("Device path %q doesn't exists yet, retrying in %d seconds (%d/%d)", *devicePath, intervalSeconds, i, maxRetries)
+			klog.InfoS("Device path doesn't exists yet, retrying", "device", *devicePath, "seconds", intervalSeconds, "retries", 1, "max", maxRetries)
 			sleep(time.Second * time.Duration(intervalSeconds))
 		}
 
@@ -186,10 +188,10 @@ func pathExists(devicePath *string, deviceTransport string) error {
 		_, err := osStat(*devicePath)
 		if err != nil {
 			if !os.IsNotExist(err) {
-				debug.Printf("Error attempting to stat device: %s", err.Error())
+				klog.ErrorS(err, "Error attempting to stat device")
 				return err
 			}
-			debug.Printf("Device not found for: %s", *devicePath)
+			klog.InfoS("Device not found", "device", *devicePath)
 			return err
 		}
 	} else {
@@ -214,18 +216,18 @@ func pathExists(devicePath *string, deviceTransport string) error {
 func getMultipathDevice(devices []Device) (*Device, error) {
 	var multipathDevice *Device
 
+	// This routine relies on output from lsblk, and older versions did not produce the desired outcome
+	// of a child row, followed by a parent row. This routine now just takes the first parent found.
 	for _, device := range devices {
+		klog.InfoS("find multipath device", "device", device)
 		if len(device.Children) != 1 {
-			multipathdNotRunning := ""
-			if len(device.Children) == 0 {
-				multipathdNotRunning = " (is multipathd running?)"
-			}
-			return nil, fmt.Errorf("device is not mapped to exactly one multipath device%s: %v", multipathdNotRunning, device.Children)
+			klog.InfoS("WARNING: children != 1", "name", device.Name)
 		}
-		if multipathDevice != nil && device.Children[0].Name != multipathDevice.Name {
-			return nil, fmt.Errorf("devices don't share a common multipath device: %v", devices)
+		if len(device.Children) == 1 {
+			multipathDevice = &device.Children[0]
+			klog.InfoS("SET: multipath device", "name", multipathDevice.Name)
+			break
 		}
-		multipathDevice = &device.Children[0]
 	}
 
 	if multipathDevice == nil {
@@ -239,7 +241,7 @@ func getMultipathDevice(devices []Device) (*Device, error) {
 	return multipathDevice, nil
 }
 
-// Connect is for backward-compatiblity with c.Connect()
+// Connect is for backward-compatibility with c.Connect()
 func Connect(c Connector) (string, error) {
 	return c.Connect()
 }
@@ -272,7 +274,7 @@ func (c *Connector) Connect() (string, error) {
 		if err != nil {
 			lastErr = err
 		} else {
-			debug.Printf("Appending device path: %s", devicePath)
+			klog.InfoS("Appending device path", "device", devicePath)
 			devicePaths = append(devicePaths, devicePath)
 		}
 	}
@@ -285,6 +287,7 @@ func (c *Connector) Connect() (string, error) {
 	}
 
 	if len(c.Devices) < 1 {
+		klog.ErrorS(lastErr, "failed to find device path", "length", len(c.Devices))
 		iscsiCmd([]string{"-m", "iface", "-I", iFace, "-o", "delete"}...)
 		return "", fmt.Errorf("failed to find device path: %s, last error seen: %v", devicePaths, lastErr)
 	}
@@ -292,7 +295,7 @@ func (c *Connector) Connect() (string, error) {
 	mountTargetDevice, err := c.getMountTargetDevice()
 	c.MountTargetDevice = mountTargetDevice
 	if err != nil {
-		debug.Printf("Connect failed: %v", err)
+		klog.ErrorS(err, "Connect failed")
 		err := RemoveSCSIDevices(c.Devices...)
 		if err != nil {
 			return "", err
@@ -312,7 +315,7 @@ func (c *Connector) Connect() (string, error) {
 }
 
 func (c *Connector) connectTarget(targetIqn string, target string, iFace string, iscsiTransport string) (string, error) {
-	debug.Printf("Process targetIqn: %s, portal: %s\n", targetIqn, target)
+	klog.InfoS("Connect target", "iqn", targetIqn, "portal", target)
 	targetParts := strings.Split(target, ":")
 	targetPortal := targetParts[0]
 	targetPort := defaultPort
@@ -323,9 +326,9 @@ func (c *Connector) connectTarget(targetIqn string, target string, iFace string,
 	// Rescan sessions to discover newly mapped LUNs. Do not specify the interface when rescanning
 	// to avoid establishing additional sessions to the same target.
 	if _, err := iscsiCmd(append(baseArgs, []string{"-R"}...)...); err != nil {
-		debug.Printf("Failed to rescan session, err: %v", err)
+		klog.ErrorS(err, "Failed to rescan session")
 		if os.IsTimeout(err) {
-			debug.Printf("iscsiadm timeouted, logging out")
+			klog.InfoS("iscsiadm timed out, logging out")
 			cmd := execCommand("iscsiadm", append(baseArgs, []string{"-u"}...)...)
 			out, err := cmd.CombinedOutput()
 			if err != nil {
@@ -344,7 +347,7 @@ func (c *Connector) connectTarget(targetIqn string, target string, iFace string,
 
 	exists, _ := sessionExists(portal, targetIqn)
 	if exists {
-		debug.Printf("Session already exists, checking if device path %q exists", devicePath)
+		klog.InfoS("Session already exists, checking if device path exists", "device", devicePath)
 		if err := waitForPathToExist(&devicePath, c.RetryCount, c.CheckInterval, iscsiTransport); err != nil {
 			return "", err
 		}
@@ -358,11 +361,11 @@ func (c *Connector) connectTarget(targetIqn string, target string, iFace string,
 	// perform the login
 	err := Login(targetIqn, portal)
 	if err != nil {
-		debug.Printf("Failed to login: %v", err)
+		klog.ErrorS(err, "Failed to login")
 		return "", err
 	}
 
-	debug.Printf("Waiting for device path %q to exist", devicePath)
+	klog.InfoS("Waiting for device path to exist", "device", devicePath)
 	if err := waitForPathToExist(&devicePath, c.RetryCount, c.CheckInterval, iscsiTransport); err != nil {
 		return "", err
 	}
@@ -374,7 +377,7 @@ func (c *Connector) discoverTarget(targetIqn string, iFace string, portal string
 	if c.DoDiscovery {
 		// build discoverydb and discover iscsi target
 		if err := Discoverydb(portal, iFace, c.DiscoverySecrets, c.DoCHAPDiscovery); err != nil {
-			debug.Printf("Error in discovery of the target: %s\n", err.Error())
+			klog.ErrorS(err, "Error in discovery of the target")
 			return err
 		}
 	}
@@ -383,7 +386,7 @@ func (c *Connector) discoverTarget(targetIqn string, iFace string, portal string
 		// Make sure we don't log the secrets
 		err := CreateDBEntry(targetIqn, portal, iFace, c.DiscoverySecrets, c.SessionSecrets)
 		if err != nil {
-			debug.Printf("Error creating db entry: %s\n", err.Error())
+			klog.ErrorS(err, "Error creating db entry")
 			return err
 		}
 	}
@@ -435,7 +438,7 @@ func (c *Connector) DisconnectVolume() error {
 			return fmt.Errorf("multipath is inconsistent: %v", err)
 		}
 
-		debug.Printf("Removing multipath device in path %s.\n", c.MountTargetDevice.GetPath())
+		klog.InfoS("Removing multipath device in path", "device", c.MountTargetDevice.GetPath())
 		err := FlushMultipathDevice(c.MountTargetDevice)
 		if err != nil {
 			return err
@@ -445,13 +448,13 @@ func (c *Connector) DisconnectVolume() error {
 		}
 	} else {
 		devicePath := c.MountTargetDevice.GetPath()
-		debug.Printf("Removing normal device in path %s.\n", devicePath)
+		klog.InfoS("Removing normal device in path", "device", devicePath)
 		if err := RemoveSCSIDevices(*c.MountTargetDevice); err != nil {
 			return err
 		}
 	}
 
-	debug.Printf("Finished disconnecting volume.\n")
+	klog.InfoS("Finished disconnecting volume.")
 	return nil
 }
 
@@ -460,10 +463,10 @@ func (c *Connector) getMountTargetDevice() (*Device, error) {
 	if len(c.Devices) > 1 {
 		multipathDevice, err := getMultipathDevice(c.Devices)
 		if err != nil {
-			debug.Printf("mount target is not a multipath device: %v", err)
+			klog.ErrorS(err, "Mount target is not a multipath device")
 			return nil, err
 		}
-		debug.Printf("mount target is a multipath device")
+		klog.InfoS("Mount target is a multipath device")
 		return multipathDevice, nil
 	}
 
@@ -482,11 +485,11 @@ func (c *Connector) IsMultipathEnabled() bool {
 // GetSCSIDevices get SCSI devices from device paths
 // It will returns all SCSI devices if no paths are given
 func GetSCSIDevices(devicePaths []string, strict bool) ([]Device, error) {
-	debug.Printf("Getting info about SCSI devices %s.\n", devicePaths)
+	klog.InfoS("Getting info about SCSI devices", "devices", devicePaths)
 
 	deviceInfo, err := lsblk(devicePaths, strict)
 	if err != nil {
-		debug.Printf("An error occured while looking info about SCSI devices: %v", err)
+		klog.ErrorS(err, "An error occurred while looking info about SCSI devices")
 		return nil, err
 	}
 
@@ -504,6 +507,7 @@ func GetISCSIDevices(devicePaths []string, strict bool) (devices []Device, err e
 	for i := range scsiDevices {
 		device := &scsiDevices[i]
 		if device.Transport == "iscsi" {
+			klog.InfoS("append iscsi device", "device", *device)
 			devices = append(devices, *device)
 		}
 	}
@@ -515,15 +519,16 @@ func GetISCSIDevices(devicePaths []string, strict bool) (devices []Device, err e
 func lsblk(devicePaths []string, strict bool) (deviceInfo, error) {
 	flags := []string{"-rn", "-o", "NAME,KNAME,PKNAME,HCTL,TYPE,TRAN,SIZE"}
 	command := execCommand("lsblk", append(flags, devicePaths...)...)
-	debug.Println(command.String())
+	klog.InfoS("lsblk", "command", command.String())
 	out, err := command.Output()
+	klog.InfoS("lsblk", "output", out, "error", "err")
 	if err != nil {
 		if ee, ok := err.(*exec.ExitError); ok {
 			err = fmt.Errorf("%s, (%w)", strings.Trim(string(ee.Stderr), "\n"), ee)
 			if strict || ee.ExitCode() != 64 { // ignore the error if some devices have been found when not strict
 				return nil, err
 			}
-			debug.Printf("Could find only some devices: %v", err)
+			klog.ErrorS(err, "Could find only some devices")
 		} else {
 			return nil, err
 		}
@@ -537,7 +542,9 @@ func lsblk(devicePaths []string, strict bool) (deviceInfo, error) {
 	lines := strings.Split(strings.Trim(string(out), "\n"), "\n")
 	for _, line := range lines {
 		columns := strings.Split(line, " ")
+		klog.InfoS("parse devices", "columns", columns)
 		if len(columns) < 5 {
+			klog.InfoS("invalid output from lsblk", "line", line)
 			return nil, fmt.Errorf("invalid output from lsblk: %s", line)
 		}
 		device := &Device{
@@ -547,6 +554,7 @@ func lsblk(devicePaths []string, strict bool) (deviceInfo, error) {
 			Transport: columns[5],
 			Size:      columns[6],
 		}
+		klog.InfoS("append device", "column1", columns[1], "column2", columns[2], "device", device)
 		devices = append(devices, device)
 		pkNames = append(pkNames, columns[2])
 		devicesMap[columns[1]] = device
@@ -565,6 +573,7 @@ func lsblk(devicePaths []string, strict bool) (deviceInfo, error) {
 		if parent.Children == nil {
 			parent.Children = []Device{}
 		}
+		klog.InfoS("append child", "pkName", pkName, "device", *device)
 		parent.Children = append(devicesMap[pkName].Children, *device)
 	}
 
@@ -572,6 +581,7 @@ func lsblk(devicePaths []string, strict bool) (deviceInfo, error) {
 	var deviceInfo deviceInfo
 	for i, device := range devices {
 		if pkNames[i] == "" {
+			klog.InfoS("append device info", "pkName", pkNames[i], "device", *device)
 			deviceInfo = append(deviceInfo, *device)
 		}
 	}
@@ -582,17 +592,17 @@ func lsblk(devicePaths []string, strict bool) (deviceInfo, error) {
 // writeInSCSIDeviceFile write into special devices files to change devices state
 func writeInSCSIDeviceFile(hctl string, file string, content string) error {
 	filename := filepath.Join("/sys/class/scsi_device", hctl, "device", file)
-	debug.Printf("Write %q in %q.\n", content, filename)
+	klog.InfoS("Write to SCSI device", "content", content, "filename", filename)
 
 	f, err := osOpenFile(filename, os.O_TRUNC|os.O_WRONLY, 0200)
 	if err != nil {
-		debug.Printf("Error while opening file %v: %v\n", filename, err)
+		klog.ErrorS(err, "Error attempting to open file", "filename", filename)
 		return err
 	}
 
 	defer f.Close()
 	if _, err := f.WriteString(content); err != nil {
-		debug.Printf("Error while writing to file %v: %v", filename, err)
+		klog.ErrorS(err, "Error attempting to write to file", "filename", filename)
 		return err
 	}
 
@@ -601,22 +611,22 @@ func writeInSCSIDeviceFile(hctl string, file string, content string) error {
 
 // RemoveSCSIDevices removes SCSI device(s) from a Linux host.
 func RemoveSCSIDevices(devices ...Device) error {
-	debug.Printf("Removing SCSI devices %v.\n", devices)
+	klog.InfoS("Removing SCSI devices", "devices", devices)
 
 	var errs []error
 	for _, device := range devices {
-		debug.Printf("Flush SCSI device %v.\n", device.Name)
+		klog.InfoS("Flush SCSI device", "device", device.Name)
 		if err := device.Exists(); err == nil {
 			out, err := execCommand("blockdev", "--flushbufs", device.GetPath()).CombinedOutput()
 			if err != nil {
-				debug.Printf("Command 'blockdev --flushbufs %s' did not succeed to flush the device: %v\n", device.GetPath(), err)
+				klog.ErrorS(err, "Command 'blockdev --flushbufs <device>' did not succeed to flush the device", "device", device.GetPath())
 				return errors.New(string(out))
 			}
 		} else if !os.IsNotExist(err) {
 			return err
 		}
 
-		debug.Printf("Put SCSI device %q offline.\n", device.Name)
+		klog.InfoS("Put SCSI device offline", "device", device.Name)
 		err := device.Shutdown()
 		if err != nil {
 			if !os.IsNotExist(err) { // Ignore device already removed
@@ -625,7 +635,7 @@ func RemoveSCSIDevices(devices ...Device) error {
 			continue
 		}
 
-		debug.Printf("Delete SCSI device %q.\n", device.Name)
+		klog.InfoS("Delete SCSI device", "device", device.Name)
 		err = device.Delete()
 		if err != nil {
 			if !os.IsNotExist(err) { // Ignore device already removed
@@ -638,7 +648,7 @@ func RemoveSCSIDevices(devices ...Device) error {
 	if len(errs) > 0 {
 		return errs[0]
 	}
-	debug.Println("Finished removing SCSI devices.")
+	klog.InfoS("Finished removing SCSI devices.")
 	return nil
 }
 

--- a/iscsi/iscsi_test.go
+++ b/iscsi/iscsi_test.go
@@ -18,6 +18,7 @@ import (
 	"github.com/prashantv/gostub"
 	"github.com/stretchr/testify/assert"
 	"k8s.io/klog/v2"
+	"k8s.io/klog/v2/ktesting"
 )
 
 type testWriter struct {
@@ -418,12 +419,13 @@ func Test_EnableDebugLogging(t *testing.T) {
 	assert := assert.New(t)
 	data := []byte{}
 	writer := testWriter{data: &data}
-	EnableDebugLogging(writer)
+	klog.SetOutput(writer)
 
 	assert.Equal("", string(data))
 	assert.Len(strings.Split(string(data), "\n"), 1)
 
-	klog.InfoS("testing debug logs")
+	logger, _ := ktesting.NewTestContext(t)
+	logger.Info("testing debug logs")
 	assert.Contains(string(data), "testing debug logs")
 	assert.Len(strings.Split(string(data), "\n"), 2)
 }

--- a/iscsi/iscsi_test.go
+++ b/iscsi/iscsi_test.go
@@ -17,6 +17,7 @@ import (
 
 	"github.com/prashantv/gostub"
 	"github.com/stretchr/testify/assert"
+	"k8s.io/klog/v2"
 )
 
 type testWriter struct {
@@ -422,7 +423,7 @@ func Test_EnableDebugLogging(t *testing.T) {
 	assert.Equal("", string(data))
 	assert.Len(strings.Split(string(data), "\n"), 1)
 
-	debug.Print("testing debug logs")
+	klog.InfoS("testing debug logs")
 	assert.Contains(string(data), "testing debug logs")
 	assert.Len(strings.Split(string(data), "\n"), 2)
 }

--- a/iscsi/iscsiadm.go
+++ b/iscsi/iscsiadm.go
@@ -4,6 +4,8 @@ import (
 	"fmt"
 	"strings"
 	"time"
+
+	"k8s.io/klog/v2"
 )
 
 // Secrets provides optional iscsi security credentials (CHAP settings)
@@ -23,7 +25,7 @@ type Secrets struct {
 func iscsiCmd(args ...string) (string, error) {
 	stdout, err := execWithTimeout("iscsiadm", args, time.Second*3)
 
-	debug.Printf("Run iscsiadm command: %s", strings.Join(append([]string{"iscsiadm"}, args...), " "))
+	klog.InfoS("Run iscsiadm", "command", strings.Join(append([]string{"iscsiadm"}, args...), " "))
 	iscsiadmDebug(string(stdout), err)
 
 	return string(stdout), err
@@ -31,9 +33,9 @@ func iscsiCmd(args ...string) (string, error) {
 
 func iscsiadmDebug(output string, cmdError error) {
 	debugOutput := strings.Replace(output, "\n", "\\n", -1)
-	debug.Printf("Output of iscsiadm command: {output: %s}", debugOutput)
+	klog.InfoS("Output of iscsiadm command", "output", debugOutput)
 	if cmdError != nil {
-		debug.Printf("Error message returned from iscsiadm command: %s", cmdError.Error())
+		klog.ErrorS(cmdError, "Error message returned from iscsiadm command")
 	}
 }
 
@@ -41,7 +43,7 @@ func iscsiadmDebug(output string, cmdError error) {
 /// along with the raw output in Response.StdOut we add the convenience of
 // returning a list of entries found
 func ListInterfaces() ([]string, error) {
-	debug.Println("Begin ListInterface...")
+	klog.InfoS("Begin ListInterface...")
 	out, err := iscsiCmd("-m", "iface", "-o", "show")
 	return strings.Split(out, "\n"), err
 }
@@ -49,14 +51,14 @@ func ListInterfaces() ([]string, error) {
 // ShowInterface retrieves the details for the specified iscsi interface
 // caller should inspect r.Err and use r.StdOut for interface details
 func ShowInterface(iface string) (string, error) {
-	debug.Println("Begin ShowInterface...")
+	klog.InfoS("Begin ShowInterface...")
 	out, err := iscsiCmd("-m", "iface", "-o", "show", "-I", iface)
 	return out, err
 }
 
 // CreateDBEntry sets up a node entry for the specified tgt in the nodes iscsi nodes db
 func CreateDBEntry(tgtIQN, portal, iFace string, discoverySecrets, sessionSecrets Secrets) error {
-	debug.Println("Begin CreateDBEntry...")
+	klog.InfoS("Begin CreateDBEntry...")
 	baseArgs := []string{"-m", "node", "-T", tgtIQN, "-p", portal}
 	_, err := iscsiCmd(append(baseArgs, "-I", iFace, "-o", "new")...)
 	if err != nil {
@@ -64,7 +66,7 @@ func CreateDBEntry(tgtIQN, portal, iFace string, discoverySecrets, sessionSecret
 	}
 
 	if discoverySecrets.SecretsType == "chap" {
-		debug.Printf("Setting CHAP Discovery...")
+		klog.InfoS("Setting CHAP Discovery...")
 		err := createCHAPEntries(baseArgs, discoverySecrets, true)
 		if err != nil {
 			return err
@@ -72,7 +74,7 @@ func CreateDBEntry(tgtIQN, portal, iFace string, discoverySecrets, sessionSecret
 	}
 
 	if sessionSecrets.SecretsType == "chap" {
-		debug.Printf("Setting CHAP Session...")
+		klog.InfoS("Setting CHAP Session...")
 		err := createCHAPEntries(baseArgs, sessionSecrets, false)
 		if err != nil {
 			return err
@@ -85,7 +87,7 @@ func CreateDBEntry(tgtIQN, portal, iFace string, discoverySecrets, sessionSecret
 
 // Discoverydb discovers the iscsi target
 func Discoverydb(tp, iface string, discoverySecrets Secrets, chapDiscovery bool) error {
-	debug.Println("Begin Discoverydb...")
+	klog.InfoS("Begin Discoverydb...")
 	baseArgs := []string{"-m", "discoverydb", "-t", "sendtargets", "-p", tp, "-I", iface}
 	out, err := iscsiCmd(append(baseArgs, []string{"-o", "new"}...)...)
 	if err != nil {
@@ -109,7 +111,7 @@ func Discoverydb(tp, iface string, discoverySecrets Secrets, chapDiscovery bool)
 
 func createCHAPEntries(baseArgs []string, secrets Secrets, discovery bool) error {
 	args := []string{}
-	debug.Printf("Begin createCHAPEntries (discovery=%t)...", discovery)
+	klog.InfoS("Begin createCHAPEntries...", "discovery", discovery)
 	if discovery {
 		args = append(baseArgs, []string{"-o", "update",
 			"-n", "discovery.sendtargets.auth.authmethod", "-v", "CHAP",
@@ -146,14 +148,14 @@ func createCHAPEntries(baseArgs []string, secrets Secrets, discovery bool) error
 
 // GetSessions retrieves a list of current iscsi sessions on the node
 func GetSessions() (string, error) {
-	debug.Println("Begin GetSessions...")
+	klog.InfoS("Begin GetSessions...")
 	out, err := iscsiCmd("-m", "session")
 	return out, err
 }
 
 // Login performs an iscsi login for the specified target
 func Login(tgtIQN, portal string) error {
-	debug.Println("Begin Login...")
+	klog.InfoS("Begin Login...")
 	baseArgs := []string{"-m", "node", "-T", tgtIQN, "-p", portal}
 	if _, err := iscsiCmd(append(baseArgs, []string{"-l"}...)...); err != nil {
 		//delete the node record from database
@@ -165,7 +167,7 @@ func Login(tgtIQN, portal string) error {
 
 // Logout logs out the specified target
 func Logout(tgtIQN, portal string) error {
-	debug.Println("Begin Logout...")
+	klog.InfoS("Begin Logout...")
 	args := []string{"-m", "node", "-T", tgtIQN, "-p", portal, "-u"}
 	iscsiCmd(args...)
 	return nil
@@ -173,7 +175,7 @@ func Logout(tgtIQN, portal string) error {
 
 // DeleteDBEntry deletes the iscsi db entry for the specified target
 func DeleteDBEntry(tgtIQN string) error {
-	debug.Println("Begin DeleteDBEntry...")
+	klog.InfoS("Begin DeleteDBEntry...")
 	args := []string{"-m", "node", "-T", tgtIQN, "-o", "delete"}
 	iscsiCmd(args...)
 	return nil
@@ -181,7 +183,7 @@ func DeleteDBEntry(tgtIQN string) error {
 
 // DeleteIFace delete the iface
 func DeleteIFace(iface string) error {
-	debug.Println("Begin DeleteIFace...")
+	klog.InfoS("Begin DeleteIFace...")
 	iscsiCmd([]string{"-m", "iface", "-I", iface, "-o", "delete"}...)
 	return nil
 }

--- a/iscsi/iscsiadm.go
+++ b/iscsi/iscsiadm.go
@@ -1,11 +1,11 @@
 package iscsi
 
 import (
+	"context"
 	"fmt"
 	"strings"
 	"time"
 
-	"github.com/go-logr/logr"
 	"k8s.io/klog/v2"
 )
 
@@ -23,8 +23,9 @@ type Secrets struct {
 	PasswordIn string `json:"passwordIn,omitempty"`
 }
 
-func iscsiCmd(logger *logr.Logger, args ...string) (string, error) {
-	stdout, err := execWithTimeout(logger, "iscsiadm", args, time.Second*3)
+func iscsiCmd(ctx context.Context, args ...string) (string, error) {
+	logger := klog.FromContext(ctx)
+	stdout, err := execWithTimeout(ctx, "iscsiadm", args, time.Second*3)
 
 	logger.V(1).Info("Run iscsiadm", "command", strings.Join(append([]string{"iscsiadm"}, args...), " "))
 	iscsiadmDebug(logger, string(stdout), err)
@@ -32,43 +33,46 @@ func iscsiCmd(logger *logr.Logger, args ...string) (string, error) {
 	return string(stdout), err
 }
 
-func iscsiadmDebug(logger *logr.Logger, output string, cmdError error) {
+func iscsiadmDebug(logger klog.Logger, output string, cmdError error) {
 	debugOutput := strings.Replace(output, "\n", "\\n", -1)
 	logger.V(1).Info("Output of iscsiadm command", "output", debugOutput)
 	if cmdError != nil {
-		klog.ErrorS(cmdError, "Error message returned from iscsiadm command")
+		logger.Error(cmdError, "Error message returned from iscsiadm command")
 	}
 }
 
 // ListInterfaces returns a list of all iscsi interfaces configured on the node
 /// along with the raw output in Response.StdOut we add the convenience of
 // returning a list of entries found
-func ListInterfaces(logger *logr.Logger) ([]string, error) {
+func ListInterfaces(ctx context.Context) ([]string, error) {
+	logger := klog.FromContext(ctx)
 	logger.V(1).Info("Begin ListInterface...")
-	out, err := iscsiCmd(logger, "-m", "iface", "-o", "show")
+	out, err := iscsiCmd(ctx, "-m", "iface", "-o", "show")
 	return strings.Split(out, "\n"), err
 }
 
 // ShowInterface retrieves the details for the specified iscsi interface
 // caller should inspect r.Err and use r.StdOut for interface details
-func ShowInterface(logger *logr.Logger, iface string) (string, error) {
+func ShowInterface(ctx context.Context, iface string) (string, error) {
+	logger := klog.FromContext(ctx)
 	logger.V(1).Info("Begin ShowInterface...")
-	out, err := iscsiCmd(logger, "-m", "iface", "-o", "show", "-I", iface)
+	out, err := iscsiCmd(ctx, "-m", "iface", "-o", "show", "-I", iface)
 	return out, err
 }
 
 // CreateDBEntry sets up a node entry for the specified tgt in the nodes iscsi nodes db
-func CreateDBEntry(logger *logr.Logger, tgtIQN, portal, iFace string, discoverySecrets, sessionSecrets Secrets) error {
+func CreateDBEntry(ctx context.Context, tgtIQN, portal, iFace string, discoverySecrets, sessionSecrets Secrets) error {
+	logger := klog.FromContext(ctx)
 	logger.V(1).Info("Begin CreateDBEntry...")
 	baseArgs := []string{"-m", "node", "-T", tgtIQN, "-p", portal}
-	_, err := iscsiCmd(logger, append(baseArgs, "-I", iFace, "-o", "new")...)
+	_, err := iscsiCmd(ctx, append(baseArgs, "-I", iFace, "-o", "new")...)
 	if err != nil {
 		return err
 	}
 
 	if discoverySecrets.SecretsType == "chap" {
 		logger.V(1).Info("Setting CHAP Discovery...")
-		err := createCHAPEntries(logger, baseArgs, discoverySecrets, true)
+		err := createCHAPEntries(ctx, baseArgs, discoverySecrets, true)
 		if err != nil {
 			return err
 		}
@@ -76,7 +80,7 @@ func CreateDBEntry(logger *logr.Logger, tgtIQN, portal, iFace string, discoveryS
 
 	if sessionSecrets.SecretsType == "chap" {
 		logger.V(1).Info("Setting CHAP Session...")
-		err := createCHAPEntries(logger, baseArgs, sessionSecrets, false)
+		err := createCHAPEntries(ctx, baseArgs, sessionSecrets, false)
 		if err != nil {
 			return err
 		}
@@ -87,31 +91,33 @@ func CreateDBEntry(logger *logr.Logger, tgtIQN, portal, iFace string, discoveryS
 }
 
 // Discoverydb discovers the iscsi target
-func Discoverydb(logger *logr.Logger, tp, iface string, discoverySecrets Secrets, chapDiscovery bool) error {
+func Discoverydb(ctx context.Context, tp, iface string, discoverySecrets Secrets, chapDiscovery bool) error {
+	logger := klog.FromContext(ctx)
 	logger.V(1).Info("Begin Discoverydb...")
 	baseArgs := []string{"-m", "discoverydb", "-t", "sendtargets", "-p", tp, "-I", iface}
-	out, err := iscsiCmd(logger, append(baseArgs, []string{"-o", "new"}...)...)
+	out, err := iscsiCmd(ctx, append(baseArgs, []string{"-o", "new"}...)...)
 	if err != nil {
 		return fmt.Errorf("failed to create new entry of target in discoverydb, output: %v, err: %v", out, err)
 	}
 
 	if chapDiscovery {
-		if err := createCHAPEntries(logger, baseArgs, discoverySecrets, true); err != nil {
+		if err := createCHAPEntries(ctx, baseArgs, discoverySecrets, true); err != nil {
 			return err
 		}
 	}
 
-	_, err = iscsiCmd(logger, append(baseArgs, []string{"--discover"}...)...)
+	_, err = iscsiCmd(ctx, append(baseArgs, []string{"--discover"}...)...)
 	if err != nil {
 		//delete the discoverydb record
-		iscsiCmd(logger, append(baseArgs, []string{"-o", "delete"}...)...)
+		iscsiCmd(ctx, append(baseArgs, []string{"-o", "delete"}...)...)
 		return fmt.Errorf("failed to sendtargets to portal %s, err: %v", tp, err)
 	}
 	return nil
 }
 
-func createCHAPEntries(logger *logr.Logger, baseArgs []string, secrets Secrets, discovery bool) error {
+func createCHAPEntries(ctx context.Context, baseArgs []string, secrets Secrets, discovery bool) error {
 	args := []string{}
+	logger := klog.FromContext(ctx)
 	logger.V(1).Info("Begin createCHAPEntries...", "discovery", discovery)
 	if discovery {
 		args = append(baseArgs, []string{"-o", "update",
@@ -139,7 +145,7 @@ func createCHAPEntries(logger *logr.Logger, baseArgs []string, secrets Secrets, 
 		}
 	}
 
-	_, err := iscsiCmd(logger, args...)
+	_, err := iscsiCmd(ctx, args...)
 	if err != nil {
 		return fmt.Errorf("failed to update discoverydb with CHAP, err: %v", err)
 	}
@@ -148,43 +154,48 @@ func createCHAPEntries(logger *logr.Logger, baseArgs []string, secrets Secrets, 
 }
 
 // GetSessions retrieves a list of current iscsi sessions on the node
-func GetSessions(logger *logr.Logger) (string, error) {
+func GetSessions(ctx context.Context) (string, error) {
+	logger := klog.FromContext(ctx)
 	logger.V(1).Info("Begin GetSessions...")
-	out, err := iscsiCmd(logger, "-m", "session")
+	out, err := iscsiCmd(ctx, "-m", "session")
 	return out, err
 }
 
 // Login performs an iscsi login for the specified target
-func Login(logger *logr.Logger, tgtIQN, portal string) error {
+func Login(ctx context.Context, tgtIQN, portal string) error {
+	logger := klog.FromContext(ctx)
 	logger.V(1).Info("Begin Login...")
 	baseArgs := []string{"-m", "node", "-T", tgtIQN, "-p", portal}
-	if _, err := iscsiCmd(logger, append(baseArgs, []string{"-l"}...)...); err != nil {
+	if _, err := iscsiCmd(ctx, append(baseArgs, []string{"-l"}...)...); err != nil {
 		//delete the node record from database
-		iscsiCmd(logger, append(baseArgs, []string{"-o", "delete"}...)...)
+		iscsiCmd(ctx, append(baseArgs, []string{"-o", "delete"}...)...)
 		return fmt.Errorf("failed to sendtargets to portal %s, err: %v", portal, err)
 	}
 	return nil
 }
 
 // Logout logs out the specified target
-func Logout(logger *logr.Logger, tgtIQN, portal string) error {
+func Logout(ctx context.Context, tgtIQN, portal string) error {
+	logger := klog.FromContext(ctx)
 	logger.V(1).Info("Begin Logout...")
 	args := []string{"-m", "node", "-T", tgtIQN, "-p", portal, "-u"}
-	iscsiCmd(logger, args...)
+	iscsiCmd(ctx, args...)
 	return nil
 }
 
 // DeleteDBEntry deletes the iscsi db entry for the specified target
-func DeleteDBEntry(logger *logr.Logger, tgtIQN string) error {
+func DeleteDBEntry(ctx context.Context, tgtIQN string) error {
+	logger := klog.FromContext(ctx)
 	logger.V(1).Info("Begin DeleteDBEntry...")
 	args := []string{"-m", "node", "-T", tgtIQN, "-o", "delete"}
-	iscsiCmd(logger, args...)
+	iscsiCmd(ctx, args...)
 	return nil
 }
 
 // DeleteIFace delete the iface
-func DeleteIFace(logger *logr.Logger, iface string) error {
+func DeleteIFace(ctx context.Context, iface string) error {
+	logger := klog.FromContext(ctx)
 	logger.V(1).Info("Begin DeleteIFace...")
-	iscsiCmd(logger, []string{"-m", "iface", "-I", iface, "-o", "delete"}...)
+	iscsiCmd(ctx, []string{"-m", "iface", "-I", iface, "-o", "delete"}...)
 	return nil
 }

--- a/iscsi/iscsiadm.go
+++ b/iscsi/iscsiadm.go
@@ -1,11 +1,11 @@
 package iscsi
 
 import (
-	"context"
 	"fmt"
 	"strings"
 	"time"
 
+	"github.com/go-logr/logr"
 	"k8s.io/klog/v2"
 )
 
@@ -23,18 +23,16 @@ type Secrets struct {
 	PasswordIn string `json:"passwordIn,omitempty"`
 }
 
-func iscsiCmd(ctx context.Context, args ...string) (string, error) {
-	logger := klog.FromContext(ctx)
-	stdout, err := execWithTimeout(ctx, "iscsiadm", args, time.Second*3)
+func iscsiCmd(logger *logr.Logger, args ...string) (string, error) {
+	stdout, err := execWithTimeout(logger, "iscsiadm", args, time.Second*3)
 
 	logger.V(1).Info("Run iscsiadm", "command", strings.Join(append([]string{"iscsiadm"}, args...), " "))
-	iscsiadmDebug(ctx, string(stdout), err)
+	iscsiadmDebug(logger, string(stdout), err)
 
 	return string(stdout), err
 }
 
-func iscsiadmDebug(ctx context.Context, output string, cmdError error) {
-	logger := klog.FromContext(ctx)
+func iscsiadmDebug(logger *logr.Logger, output string, cmdError error) {
 	debugOutput := strings.Replace(output, "\n", "\\n", -1)
 	logger.V(1).Info("Output of iscsiadm command", "output", debugOutput)
 	if cmdError != nil {
@@ -45,35 +43,32 @@ func iscsiadmDebug(ctx context.Context, output string, cmdError error) {
 // ListInterfaces returns a list of all iscsi interfaces configured on the node
 /// along with the raw output in Response.StdOut we add the convenience of
 // returning a list of entries found
-func ListInterfaces(ctx context.Context) ([]string, error) {
-	logger := klog.FromContext(ctx)
+func ListInterfaces(logger *logr.Logger) ([]string, error) {
 	logger.V(1).Info("Begin ListInterface...")
-	out, err := iscsiCmd(ctx, "-m", "iface", "-o", "show")
+	out, err := iscsiCmd(logger, "-m", "iface", "-o", "show")
 	return strings.Split(out, "\n"), err
 }
 
 // ShowInterface retrieves the details for the specified iscsi interface
 // caller should inspect r.Err and use r.StdOut for interface details
-func ShowInterface(ctx context.Context, iface string) (string, error) {
-	logger := klog.FromContext(ctx)
+func ShowInterface(logger *logr.Logger, iface string) (string, error) {
 	logger.V(1).Info("Begin ShowInterface...")
-	out, err := iscsiCmd(ctx, "-m", "iface", "-o", "show", "-I", iface)
+	out, err := iscsiCmd(logger, "-m", "iface", "-o", "show", "-I", iface)
 	return out, err
 }
 
 // CreateDBEntry sets up a node entry for the specified tgt in the nodes iscsi nodes db
-func CreateDBEntry(ctx context.Context, tgtIQN, portal, iFace string, discoverySecrets, sessionSecrets Secrets) error {
-	logger := klog.FromContext(ctx)
+func CreateDBEntry(logger *logr.Logger, tgtIQN, portal, iFace string, discoverySecrets, sessionSecrets Secrets) error {
 	logger.V(1).Info("Begin CreateDBEntry...")
 	baseArgs := []string{"-m", "node", "-T", tgtIQN, "-p", portal}
-	_, err := iscsiCmd(ctx, append(baseArgs, "-I", iFace, "-o", "new")...)
+	_, err := iscsiCmd(logger, append(baseArgs, "-I", iFace, "-o", "new")...)
 	if err != nil {
 		return err
 	}
 
 	if discoverySecrets.SecretsType == "chap" {
 		logger.V(1).Info("Setting CHAP Discovery...")
-		err := createCHAPEntries(ctx, baseArgs, discoverySecrets, true)
+		err := createCHAPEntries(logger, baseArgs, discoverySecrets, true)
 		if err != nil {
 			return err
 		}
@@ -81,7 +76,7 @@ func CreateDBEntry(ctx context.Context, tgtIQN, portal, iFace string, discoveryS
 
 	if sessionSecrets.SecretsType == "chap" {
 		logger.V(1).Info("Setting CHAP Session...")
-		err := createCHAPEntries(ctx, baseArgs, sessionSecrets, false)
+		err := createCHAPEntries(logger, baseArgs, sessionSecrets, false)
 		if err != nil {
 			return err
 		}
@@ -92,32 +87,30 @@ func CreateDBEntry(ctx context.Context, tgtIQN, portal, iFace string, discoveryS
 }
 
 // Discoverydb discovers the iscsi target
-func Discoverydb(ctx context.Context, tp, iface string, discoverySecrets Secrets, chapDiscovery bool) error {
-	logger := klog.FromContext(ctx)
+func Discoverydb(logger *logr.Logger, tp, iface string, discoverySecrets Secrets, chapDiscovery bool) error {
 	logger.V(1).Info("Begin Discoverydb...")
 	baseArgs := []string{"-m", "discoverydb", "-t", "sendtargets", "-p", tp, "-I", iface}
-	out, err := iscsiCmd(ctx, append(baseArgs, []string{"-o", "new"}...)...)
+	out, err := iscsiCmd(logger, append(baseArgs, []string{"-o", "new"}...)...)
 	if err != nil {
 		return fmt.Errorf("failed to create new entry of target in discoverydb, output: %v, err: %v", out, err)
 	}
 
 	if chapDiscovery {
-		if err := createCHAPEntries(ctx, baseArgs, discoverySecrets, true); err != nil {
+		if err := createCHAPEntries(logger, baseArgs, discoverySecrets, true); err != nil {
 			return err
 		}
 	}
 
-	_, err = iscsiCmd(ctx, append(baseArgs, []string{"--discover"}...)...)
+	_, err = iscsiCmd(logger, append(baseArgs, []string{"--discover"}...)...)
 	if err != nil {
 		//delete the discoverydb record
-		iscsiCmd(ctx, append(baseArgs, []string{"-o", "delete"}...)...)
+		iscsiCmd(logger, append(baseArgs, []string{"-o", "delete"}...)...)
 		return fmt.Errorf("failed to sendtargets to portal %s, err: %v", tp, err)
 	}
 	return nil
 }
 
-func createCHAPEntries(ctx context.Context, baseArgs []string, secrets Secrets, discovery bool) error {
-	logger := klog.FromContext(ctx)
+func createCHAPEntries(logger *logr.Logger, baseArgs []string, secrets Secrets, discovery bool) error {
 	args := []string{}
 	logger.V(1).Info("Begin createCHAPEntries...", "discovery", discovery)
 	if discovery {
@@ -146,7 +139,7 @@ func createCHAPEntries(ctx context.Context, baseArgs []string, secrets Secrets, 
 		}
 	}
 
-	_, err := iscsiCmd(ctx, args...)
+	_, err := iscsiCmd(logger, args...)
 	if err != nil {
 		return fmt.Errorf("failed to update discoverydb with CHAP, err: %v", err)
 	}
@@ -155,48 +148,43 @@ func createCHAPEntries(ctx context.Context, baseArgs []string, secrets Secrets, 
 }
 
 // GetSessions retrieves a list of current iscsi sessions on the node
-func GetSessions(ctx context.Context) (string, error) {
-	logger := klog.FromContext(ctx)
+func GetSessions(logger *logr.Logger) (string, error) {
 	logger.V(1).Info("Begin GetSessions...")
-	out, err := iscsiCmd(ctx, "-m", "session")
+	out, err := iscsiCmd(logger, "-m", "session")
 	return out, err
 }
 
 // Login performs an iscsi login for the specified target
-func Login(ctx context.Context, tgtIQN, portal string) error {
-	logger := klog.FromContext(ctx)
+func Login(logger *logr.Logger, tgtIQN, portal string) error {
 	logger.V(1).Info("Begin Login...")
 	baseArgs := []string{"-m", "node", "-T", tgtIQN, "-p", portal}
-	if _, err := iscsiCmd(ctx, append(baseArgs, []string{"-l"}...)...); err != nil {
+	if _, err := iscsiCmd(logger, append(baseArgs, []string{"-l"}...)...); err != nil {
 		//delete the node record from database
-		iscsiCmd(ctx, append(baseArgs, []string{"-o", "delete"}...)...)
+		iscsiCmd(logger, append(baseArgs, []string{"-o", "delete"}...)...)
 		return fmt.Errorf("failed to sendtargets to portal %s, err: %v", portal, err)
 	}
 	return nil
 }
 
 // Logout logs out the specified target
-func Logout(ctx context.Context, tgtIQN, portal string) error {
-	logger := klog.FromContext(ctx)
+func Logout(logger *logr.Logger, tgtIQN, portal string) error {
 	logger.V(1).Info("Begin Logout...")
 	args := []string{"-m", "node", "-T", tgtIQN, "-p", portal, "-u"}
-	iscsiCmd(ctx, args...)
+	iscsiCmd(logger, args...)
 	return nil
 }
 
 // DeleteDBEntry deletes the iscsi db entry for the specified target
-func DeleteDBEntry(ctx context.Context, tgtIQN string) error {
-	logger := klog.FromContext(ctx)
+func DeleteDBEntry(logger *logr.Logger, tgtIQN string) error {
 	logger.V(1).Info("Begin DeleteDBEntry...")
 	args := []string{"-m", "node", "-T", tgtIQN, "-o", "delete"}
-	iscsiCmd(ctx, args...)
+	iscsiCmd(logger, args...)
 	return nil
 }
 
 // DeleteIFace delete the iface
-func DeleteIFace(ctx context.Context, iface string) error {
-	logger := klog.FromContext(ctx)
+func DeleteIFace(logger *logr.Logger, iface string) error {
 	logger.V(1).Info("Begin DeleteIFace...")
-	iscsiCmd(ctx, []string{"-m", "iface", "-I", iface, "-o", "delete"}...)
+	iscsiCmd(logger, []string{"-m", "iface", "-I", iface, "-o", "delete"}...)
 	return nil
 }

--- a/iscsi/iscsiadm_test.go
+++ b/iscsi/iscsiadm_test.go
@@ -6,6 +6,7 @@ import (
 
 	"github.com/prashantv/gostub"
 	"github.com/stretchr/testify/assert"
+	"k8s.io/klog/v2/ktesting"
 )
 
 const defaultInterface = `
@@ -68,6 +69,7 @@ iface.discovery_logout = <empty>
 `
 
 func TestDiscovery(t *testing.T) {
+	_, ctx := ktesting.NewTestContext(t)
 	tests := map[string]struct {
 		tgtPortal       string
 		iface           string
@@ -127,8 +129,8 @@ iscsiadm: Could not perform SendTargets discovery.\n`,
 
 	for name, tt := range tests {
 		t.Run(name, func(t *testing.T) {
-			defer gostub.Stub(&execWithTimeout, makeFakeExecWithTimeout(false, []byte(tt.mockedStdout), tt.mockedCmdError)).Reset()
-			err := Discoverydb(tt.tgtPortal, tt.iface, tt.discoverySecret, tt.chapDiscovery)
+			defer gostub.Stub(&execWithTimeout, makeFakeExecWithTimeout(ctx, false, []byte(tt.mockedStdout), tt.mockedCmdError)).Reset()
+			err := Discoverydb(ctx, tt.tgtPortal, tt.iface, tt.discoverySecret, tt.chapDiscovery)
 			if (err != nil) != tt.wantErr {
 				t.Errorf("Discoverydb() error = %v, wantErr %v", err, tt.wantErr)
 				return
@@ -138,6 +140,7 @@ iscsiadm: Could not perform SendTargets discovery.\n`,
 }
 
 func TestCreateDBEntry(t *testing.T) {
+	_, ctx := ktesting.NewTestContext(t)
 	tests := map[string]struct {
 		tgtPortal       string
 		tgtIQN          string
@@ -177,8 +180,8 @@ func TestCreateDBEntry(t *testing.T) {
 
 	for name, tt := range tests {
 		t.Run(name, func(t *testing.T) {
-			defer gostub.Stub(&execWithTimeout, makeFakeExecWithTimeout(false, []byte(tt.mockedStdout), tt.mockedCmdError)).Reset()
-			err := CreateDBEntry(tt.tgtIQN, tt.tgtPortal, tt.iface, tt.discoverySecret, tt.sessionSecret)
+			defer gostub.Stub(&execWithTimeout, makeFakeExecWithTimeout(ctx, false, []byte(tt.mockedStdout), tt.mockedCmdError)).Reset()
+			err := CreateDBEntry(ctx, tt.tgtIQN, tt.tgtPortal, tt.iface, tt.discoverySecret, tt.sessionSecret)
 			if (err != nil) != tt.wantErr {
 				t.Errorf("CreateDBEntry() error = %v, wantErr %v", err, tt.wantErr)
 				return
@@ -189,6 +192,7 @@ func TestCreateDBEntry(t *testing.T) {
 }
 
 func TestListInterfaces(t *testing.T) {
+	_, ctx := ktesting.NewTestContext(t)
 	tests := map[string]struct {
 		mockedStdout   string
 		mockedCmdError error
@@ -224,8 +228,8 @@ func TestListInterfaces(t *testing.T) {
 	for name, tt := range tests {
 		t.Run(name, func(t *testing.T) {
 			assert := assert.New(t)
-			defer gostub.Stub(&execWithTimeout, makeFakeExecWithTimeout(false, []byte(tt.mockedStdout), tt.mockedCmdError)).Reset()
-			interfaces, err := ListInterfaces()
+			defer gostub.Stub(&execWithTimeout, makeFakeExecWithTimeout(ctx, false, []byte(tt.mockedStdout), tt.mockedCmdError)).Reset()
+			interfaces, err := ListInterfaces(ctx)
 
 			if tt.wantErr {
 				assert.NotNil(err)
@@ -238,6 +242,7 @@ func TestListInterfaces(t *testing.T) {
 }
 
 func TestShowInterface(t *testing.T) {
+	_, ctx := ktesting.NewTestContext(t)
 	tests := map[string]struct {
 		mockedStdout   string
 		mockedCmdError error
@@ -261,8 +266,8 @@ func TestShowInterface(t *testing.T) {
 	for name, tt := range tests {
 		t.Run(name, func(t *testing.T) {
 			assert := assert.New(t)
-			defer gostub.Stub(&execWithTimeout, makeFakeExecWithTimeout(false, []byte(tt.mockedStdout), tt.mockedCmdError)).Reset()
-			interfaces, err := ShowInterface("default")
+			defer gostub.Stub(&execWithTimeout, makeFakeExecWithTimeout(ctx, false, []byte(tt.mockedStdout), tt.mockedCmdError)).Reset()
+			interfaces, err := ShowInterface(ctx, "default")
 
 			if tt.wantErr {
 				assert.NotNil(err)

--- a/iscsi/multipath.go
+++ b/iscsi/multipath.go
@@ -9,12 +9,12 @@ import (
 	"strings"
 	"time"
 
+	"github.com/go-logr/logr"
 	"k8s.io/klog/v2"
 )
 
 // ExecWithTimeout execute a command with a timeout and returns an error if timeout is excedeed
-func ExecWithTimeout(ctx context.Context, command string, args []string, timeout time.Duration) ([]byte, error) {
-	logger := klog.FromContext(ctx)
+func ExecWithTimeout(logger *logr.Logger, command string, args []string, timeout time.Duration) ([]byte, error) {
 	logger.V(1).Info("Executing command with timeout", "command", command, "args", args)
 
 	// Create a new context and add a timeout to it
@@ -50,13 +50,12 @@ func ExecWithTimeout(ctx context.Context, command string, args []string, timeout
 }
 
 // FlushMultipathDevice flushes a multipath device dm-x with command multipath -f /dev/dm-x
-func FlushMultipathDevice(ctx context.Context, device *Device) error {
+func FlushMultipathDevice(logger *logr.Logger, device *Device) error {
 	devicePath := device.GetPath()
-	logger := klog.FromContext(ctx)
 	logger.V(1).Info("Flushing multipath device", "device", devicePath)
 
 	timeout := 5 * time.Second
-	_, err := execWithTimeout(ctx, "multipath", []string{"-f", devicePath}, timeout)
+	_, err := execWithTimeout(logger, "multipath", []string{"-f", devicePath}, timeout)
 
 	if err != nil {
 		if _, e := osStat(devicePath); os.IsNotExist(e) {

--- a/iscsi/multipath_test.go
+++ b/iscsi/multipath_test.go
@@ -8,9 +8,11 @@ import (
 
 	"github.com/prashantv/gostub"
 	"github.com/stretchr/testify/assert"
+	"k8s.io/klog/v2/ktesting"
 )
 
 func TestExecWithTimeout(t *testing.T) {
+	_, ctx := ktesting.NewTestContext(t)
 	tests := map[string]struct {
 		mockedStdout     string
 		mockedExitStatus int
@@ -58,7 +60,7 @@ func TestExecWithTimeout(t *testing.T) {
 				return makeFakeExecCommandContext(tt.mockedExitStatus, tt.mockedStdout)(ctx, command, args...)
 			}).Reset()
 
-			out, err := ExecWithTimeout("dummy", []string{}, timeout)
+			out, err := ExecWithTimeout(ctx, "dummy", []string{}, timeout)
 
 			if tt.wantTimeout || tt.mockedExitStatus != 0 {
 				assert.NotNil(err)


### PR DESCRIPTION
Related to https://kubernetes.io/blog/2022/05/25/contextual-logging/ and https://github.com/kubernetes/enhancements/blob/master/keps/sig-instrumentation/1602-structured-logging/README.md

The main reason for this change is to allow drivers and libraries to use the same klog logging package, and to switch to using structured logging throughout the library. From my understanding, klog is the most common Kubernetes logger and this allows consistent log output for CSI drivers and the iSCSI library.

Signed-off-by: Joe Skazinski <joseph.skazinski@seagate.com>

**What type of PR is this?**
/kind feature

**What this PR does / why we need it**:

Converts the library to using "k8s.io/klog/v2" and specifically structured logging and contextual logging.
Addresses one issue allowing the code to work with older and newer versions of lsblk.

**Which issue(s) this PR fixes**:

**Special notes for your reviewer**:
This change does not disable logging by default, but does allow the user to set their own verbosity level using -v=#. This is a change from the prior default behavior and breaks the API. This change uses structured logging and captures the same information with no loss, but with the possibility of additional information being provided where it proves useful in the particular context.

**Does this PR introduce a user-facing change?**:
Yes, the structure of the log information is presented in the klog format versus the prior formatting. Each log entry contains the same relevant information, such as timestamp and level (Info vs Error), and library values, but the the text outline is changed and will affect any scripts scraping the logs.

```release-note
Refactored to use klog/v2 and structured logging and contextual logging.
- Requires that external callers pass a context.
- Switched to using go 1.18 
- using k8s.io/klog/v2 klog replacing log.Logger
- debug.Printf calls are replaced with logger.Info and logger.Error (according to info versus error)
- getMultipathDevice() was altered to accept a new parameter and work with older versions of lsblk output and newer versions. See https://github.com/kubernetes-csi/csi-lib-iscsi/issues/34
```
