### PR TITLE
Correct the formatting issue in iscsiadm ListInterface

### DIFF
--- a/iscsi/iscsiadm.go
+++ b/iscsi/iscsiadm.go
@@ -38,7 +38,7 @@ func iscsiadmDebug(output string, cmdError error) {
 }
 
 // ListInterfaces returns a list of all iscsi interfaces configured on the node
-/// along with the raw output in Response.StdOut we add the convenience of
+// along with the raw output in Response.StdOut we add the convenience of
 // returning a list of entries found
 func ListInterfaces() ([]string, error) {
 	debug.Println("Begin ListInterface...")


### PR DESCRIPTION
This formatting issue has been reported under csi-driver-iscsi repo
and blocking the PR merge.

https://github.com/kubernetes-csi/csi-driver-iscsi/pull/141

Signed-off-by: Humble Chirammal <hchiramm@redhat.com>


> /kind cleanup

```release-note
NONE
```
