### PR TITLE
Fix CI: pin actions to SHAs, upgrade golangci-lint, fix flaky test

### DIFF
--- a/.github/workflows/static.yaml
+++ b/.github/workflows/static.yaml
@@ -15,5 +15,5 @@ jobs:
             - name: Run linter
               uses: golangci/golangci-lint-action@3a919529898de77ec3da873e3063ca4b10e7f5cc # v3
               with:
-                  version: v1.51
-                  args: -E=gofmt,deadcode,unused,varcheck,ineffassign,revive,misspell,exportloopref,asciicheck,bodyclose,contextcheck,depguard,dogsled,durationcheck,errname,forbidigo -D=staticcheck --timeout=30m0s
+                  version: v1.64
+                  args: -E=gofmt,unused,ineffassign,revive,misspell,asciicheck,bodyclose,contextcheck,dogsled,durationcheck,errname,forbidigo -D=staticcheck --timeout=30m0s

--- a/.github/workflows/trivy.yaml
+++ b/.github/workflows/trivy.yaml
@@ -8,13 +8,13 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Set up Go 1.x
-        uses: actions/setup-go@v4
+        uses: actions/setup-go@7b8cf10d4e4a01d4992d18a89f4d7dc5a3e6d6f4 # v4
         with:
           go-version: ^1.19
         id: go
 
       - name: Checkout code
-        uses: actions/checkout@v3
+        uses: actions/checkout@f43a0e5ff2bd294095638e18286ca9a3d1956744 # v3
       
       - name: Build a binary
         run: |

--- a/iscsi/iscsi_test.go
+++ b/iscsi/iscsi_test.go
@@ -106,14 +106,8 @@ func makeFakeExecCommand(exitStatus int, stdout string) func(string, ...string) 
 	}
 }
 
-func makeFakeExecCommandContext(exitStatus int, stdout string) func(context.Context, string, ...string) *exec.Cmd {
-	return func(ctx context.Context, command string, args ...string) *exec.Cmd {
-		return makeFakeExecCommand(exitStatus, stdout)(command, args...)
-	}
-}
-
 func makeFakeExecWithTimeout(withTimeout bool, output []byte, err error) func(string, []string, time.Duration) ([]byte, error) {
-	return func(command string, args []string, timeout time.Duration) ([]byte, error) {
+	return func(_ string, _ []string, _ time.Duration) ([]byte, error) {
 		if withTimeout {
 			return nil, context.DeadlineExceeded
 		}
@@ -136,6 +130,7 @@ func marshalDeviceInfo(d *deviceInfo) string {
 }
 
 func TestExecCommandHelper(t *testing.T) {
+	_ = t // This function is used as a subprocess helper, not a real test
 	if os.Getenv("GO_WANT_HELPER_PROCESS") != "1" {
 		return
 	}
@@ -296,7 +291,7 @@ func Test_sessionExists(t *testing.T) {
 
 func Test_DisconnectNormalVolume(t *testing.T) {
 	deleteDeviceFile := "/tmp/deleteDevice"
-	defer gostub.Stub(&osOpenFile, func(name string, flag int, perm os.FileMode) (*os.File, error) {
+	defer gostub.Stub(&osOpenFile, func(_ string, flag int, perm os.FileMode) (*os.File, error) {
 		return os.OpenFile(deleteDeviceFile, flag, perm)
 	}).Reset()
 
@@ -341,7 +336,7 @@ func Test_DisconnectNormalVolume(t *testing.T) {
 }
 
 func Test_DisconnectMultipathVolume(t *testing.T) {
-	defer gostub.Stub(&osStat, func(name string) (os.FileInfo, error) {
+	defer gostub.Stub(&osStat, func(_ string) (os.FileInfo, error) {
 		return nil, nil
 	}).Reset()
 
@@ -455,13 +450,13 @@ func Test_waitForPathToExist(t *testing.T) {
 				}
 				return nil
 			}
-			defer gostub.Stub(&osStat, func(name string) (os.FileInfo, error) {
+			defer gostub.Stub(&osStat, func(_ string) (os.FileInfo, error) {
 				if err := doAttempt(os.ErrPermission); err != nil {
 					return nil, err
 				}
 				return nil, nil
 			}).Reset()
-			defer gostub.Stub(&filepathGlob, func(name string) ([]string, error) {
+			defer gostub.Stub(&filepathGlob, func(_ string) ([]string, error) {
 				if err := doAttempt(filepath.ErrBadPattern); err != nil {
 					return nil, err
 				}
@@ -513,7 +508,7 @@ func Test_waitForPathToExist(t *testing.T) {
 
 	t.Run("PathNotFound", func(t *testing.T) {
 		assert := assert.New(t)
-		defer gostub.Stub(&filepathGlob, func(name string) ([]string, error) {
+		defer gostub.Stub(&filepathGlob, func(_ string) ([]string, error) {
 			return nil, nil
 		}).Reset()
 

--- a/iscsi/multipath_test.go
+++ b/iscsi/multipath_test.go
@@ -12,67 +12,52 @@ import (
 
 func TestExecWithTimeout(t *testing.T) {
 	tests := map[string]struct {
-		mockedStdout     string
-		mockedExitStatus int
-		wantTimeout      bool
+		wantOutput  string
+		wantErr     bool
+		wantTimeout bool
+		stubCmd     func(ctx context.Context, command string, args ...string) *exec.Cmd
 	}{
 		"Success": {
-			mockedStdout:     "some output",
-			mockedExitStatus: 0,
-			wantTimeout:      false,
+			wantOutput: "some output",
+			stubCmd: func(ctx context.Context, _ string, _ ...string) *exec.Cmd {
+				return exec.CommandContext(ctx, "echo", "-n", "some output")
+			},
 		},
 		"WithError": {
-			mockedStdout:     "some\noutput",
-			mockedExitStatus: 1,
-			wantTimeout:      false,
+			wantErr: true,
+			stubCmd: func(ctx context.Context, _ string, _ ...string) *exec.Cmd {
+				return exec.CommandContext(ctx, "false")
+			},
 		},
 		"WithTimeout": {
-			mockedStdout:     "",
-			mockedExitStatus: 0,
-			wantTimeout:      true,
-		},
-		"WithTimeoutAndOutput": {
-			mockedStdout:     "should not be returned",
-			mockedExitStatus: 0,
-			wantTimeout:      true,
-		},
-		"WithTimeoutAndError": {
-			mockedStdout:     "",
-			mockedExitStatus: 1,
-			wantTimeout:      true,
+			wantTimeout: true,
+			stubCmd: func(ctx context.Context, _ string, _ ...string) *exec.Cmd {
+				// "sleep 999" will block until the context deadline kills it
+				return exec.CommandContext(ctx, "sleep", "999")
+			},
 		},
 	}
 	for name, tt := range tests {
 		t.Run(name, func(t *testing.T) {
 			assert := assert.New(t)
 
-			timeout := time.Second
+			timeout := 5 * time.Second
 			if tt.wantTimeout {
-				timeout = time.Millisecond * 50
+				timeout = 50 * time.Millisecond
 			}
 
-			defer gostub.Stub(&execCommandContext, func(ctx context.Context, command string, args ...string) *exec.Cmd {
-				if tt.wantTimeout {
-					time.Sleep(timeout + time.Millisecond*10)
-				}
-				return makeFakeExecCommandContext(tt.mockedExitStatus, tt.mockedStdout)(ctx, command, args...)
-			}).Reset()
+			defer gostub.Stub(&execCommandContext, tt.stubCmd).Reset()
 
 			out, err := ExecWithTimeout("dummy", []string{}, timeout)
 
-			if tt.wantTimeout || tt.mockedExitStatus != 0 {
+			if tt.wantTimeout {
+				assert.ErrorIs(err, context.DeadlineExceeded)
+				assert.Empty(out)
+			} else if tt.wantErr {
 				assert.NotNil(err)
-				if tt.wantTimeout {
-					assert.Equal(context.DeadlineExceeded, err)
-				}
 			} else {
 				assert.Nil(err)
-			}
-
-			if tt.wantTimeout {
-				assert.Equal("", string(out))
-			} else {
-				assert.Equal(tt.mockedStdout, string(out))
+				assert.Equal(tt.wantOutput, string(out))
 			}
 		})
 	}


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:

1. If this is your first time, please read our contributor guidelines: https://git.k8s.io/community/contributors/guide#your-first-contribution and developer guide https://git.k8s.io/community/contributors/devel/development.md#development-guide
2. Please label this pull request according to what type of issue you are addressing, especially if this is a release targeted pull request. For reference on required PR/issue labels, read here:
https://git.k8s.io/community/contributors/devel/release.md#issue-kind-label
3. Ensure you have added or ran the appropriate tests for your PR: https://git.k8s.io/community/contributors/devel/testing.md
4. If you want *faster* PR reviews, read how: https://git.k8s.io/community/contributors/guide/pull-requests.md#best-practices-for-faster-reviews
5. Follow the instructions for writing a release note: https://git.k8s.io/community/contributors/guide/release-notes.md
6. If the PR is unfinished, see how to mark it: https://git.k8s.io/community/contributors/guide/pull-requests.md#marking-unfinished-pull-requests
-->

**What type of PR is this?**

/kind cleanup
/kind failing-test

<!--
Add one of the following kinds:
/kind bug
/kind cleanup
/kind documentation
/kind feature
/kind design

Optionally add one or more of the following kinds if applicable:
/kind api-change
/kind deprecation
/kind failing-test
/kind flake
/kind regression
-->

**What this PR does / why we need it**:

CI in this repo is failing across three jobs, this PR fixes that.

1. Trivy scanner is blocked by the repo's policy requiring actions pinned to commit SHAs.

2. Static checks (golangci-lint) had several issues, including a panick and enabled linters that were deprecated or broken in the newer versions.

3. `TestExecWithTimeout/Success` is flaky. I've updated the test to make it deterministic and roughly ~10x faster.

**Which issue(s) this PR fixes**:
<!-- 
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
_If PR is about `failing-tests or flakes`, please post the related issues/tests in a comment and do not use `Fixes`_*
-->
Fixes # CI

**Special notes for your reviewer**:

CI

**Release note**:
```
none
```
